### PR TITLE
Fix setting preset mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setuptools.setup(
         "Bug Tracker": "https://github.com/mtrab/pydanfossally/issues",
     },
     install_requires=["requests>=2.28.0"],
-    version="0.0.29",
+    version="0.0.30",
 )


### PR DESCRIPTION
In testing an automation of preset mode (home or away) in my Home Assistant setup, I found that setting operating mode through the Danfoss Ally API did not have an effect all the way to the actual TRVs in my home. The mode was updated correctly when querying the API afterwards, but the valves did not actually open/close as expected and my home got cold.

When setting mode in the official Ally mobile app, the valves reacted as expected, so I took a look at what the API would return after setting mode in the app. I discovered that a property called `last_click_time` was also being set, so I implemented the change in this PR and that made the valves respond to the changes made through the API.

Unfortunately, the format of this property is rather obscure and completely undocumented. I played around with setting mode in the app and querying the API afterwards and it turns out that the format includes not just the current time (in minute resolution), but also encodes the mode as part of this string (even though the mode is its own property as well).

Sigh... 😔

The format I have discovered through this reverse engineering is `YYYYmmddHHMM{{mode_in_last_click_time_format}}` where `{{mode_in_last_click_time_format}}` takes the following values (there are probably more that I have not yet discovered):

| mode | mode_in_last_click_time_format |
|--------|--------|
| at_home | 010000 |
| leaving_home | 000101 | 

This is one of the worst things I have seen in a while and it's obviously bad that none of this is documented for us hobbyist developers, but unfortunately it seems like this is indeed what it takes to make setting the preset mode actually have effect on TRVs.

It would be great if someone else was able to test and verify this behaviour in their setup. For me, it's clearly evident by changing preset mode from "away" to "home" on a cold day and looking at the new valve opening diagnostic sensor whether the valve actually opens (or just touching the radiator). The valve just doesn't open, but it does if I include this `last_click_time` weirdness.

Apologies for the wall of text, but this is just one of those things that's a little tricky to explain succinctly.