### PR TITLE
Remove print statement for JSON response

### DIFF
--- a/pydanfossally/danfossallyapi.py
+++ b/pydanfossally/danfossallyapi.py
@@ -75,7 +75,6 @@ class DanfossAllyAPI:
         response = req.json()
         if payload:
             _LOGGER.debug("Command response: %s", response)
-        print("JSON: ", response)
         return response
 
     def _refresh_token(self) -> bool:


### PR DESCRIPTION
Remove print statement. It looks like there is already logging available if the output is actually needed