### PR TITLE
Fix lazy async client initialization

### DIFF
--- a/pydanfossally/danfossallyapi.py
+++ b/pydanfossally/danfossallyapi.py
@@ -1,6 +1,7 @@
 """Async communication layer for the Danfoss Ally API."""
 from __future__ import annotations
 
+import asyncio
 import base64
 import datetime
 import json
@@ -48,11 +49,8 @@ class DanfossAllyAPI:
         self._token = ""
         self._refresh_at = datetime.datetime.min
         self._owns_client = client is None
-        self._client = client or httpx.AsyncClient(
-            base_url=API_HOST,
-            timeout=timeout,
-            headers={"Accept": "application/json"},
-        )
+        self._timeout = timeout
+        self._client = client
 
     async def __aenter__(self) -> DanfossAllyAPI:
         """Allow async context manager usage."""
@@ -64,8 +62,19 @@ class DanfossAllyAPI:
 
     async def aclose(self) -> None:
         """Close the underlying async HTTP client when owned by this instance."""
-        if self._owns_client:
+        if self._owns_client and self._client is not None:
             await self._client.aclose()
+
+    async def _async_get_client(self) -> httpx.AsyncClient:
+        """Create the default async HTTP client on first use."""
+        if self._client is None:
+            self._client = await asyncio.to_thread(
+                httpx.AsyncClient,
+                base_url=API_HOST,
+                timeout=self._timeout,
+                headers={"Accept": "application/json"},
+            )
+        return self._client
 
     def _generate_base64_token(self, key: str, secret: str) -> str:
         """Generate a base64 encoded client credential token."""
@@ -101,9 +110,10 @@ class DanfossAllyAPI:
             await self._refresh_token()
 
         request_headers = headers or self._auth_headers()
+        client = await self._async_get_client()
 
         try:
-            response = await self._client.request(
+            response = await client.request(
                 method,
                 path,
                 json=payload,
@@ -161,9 +171,10 @@ class DanfossAllyAPI:
 
         base64_token = self._generate_base64_token(self._key, self._secret)
         post_data = "grant_type=client_credentials"
+        client = await self._async_get_client()
 
         try:
-            req = await self._client.post(
+            req = await client.post(
                 TOKEN_PATH,
                 content=post_data,
                 headers=self._basic_auth_headers(base64_token),

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import unittest
+from unittest.mock import patch
 
 import httpx
 
@@ -33,6 +34,28 @@ DEVICE_PAYLOAD = {
 
 class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
     """Exercise the async-first client stack."""
+
+    async def test_default_http_client_is_created_lazily(self) -> None:
+        """The default HTTP client should not be created during __init__."""
+        api = DanfossAllyAPI()
+
+        self.assertIsNone(api._client)
+
+        with patch("pydanfossally.danfossallyapi.httpx.AsyncClient") as async_client:
+            mocked_client = unittest.mock.AsyncMock()
+            mocked_client.post.return_value = httpx.Response(
+                200,
+                json=TOKEN_RESPONSE,
+                request=httpx.Request("POST", f"{API_HOST}/oauth2/token"),
+            )
+            async_client.return_value = mocked_client
+
+            result = await api.get_token("key", "secret")
+
+        self.assertTrue(result)
+        async_client.assert_called_once()
+        mocked_client.post.assert_awaited_once()
+        await api.aclose()
 
     async def _make_api(self, handler) -> DanfossAllyAPI:
         client = httpx.AsyncClient(


### PR DESCRIPTION
Summary
- lazily create the default httpx async client on first use instead of in __init__
- avoid blocking SSL/certifi setup during object construction in async integrations

Changes
- defer default AsyncClient creation until the first request/token fetch
- create the default client via asyncio.to_thread
- add a regression test for lazy client creation

Testing
- python -m pytest -q tests/test_async_client.py
- ruff check pydanfossally tests

Notes
- keeps externally injected clients unchanged
- intended to unblock Home Assistant integrations that construct the wrapper inside the event loop