### PR TITLE
Enhance thermostat write semantics

### DIFF
--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -51,6 +52,7 @@ _MODE_TO_SETPOINT_CODE = {
     "holiday": "holiday_setting",
     "holiday_sat": "at_home_setting",
 }
+_REFRESH_DEVICE_CONCURRENCY = 5
 
 
 def _normalize_bool(value: Any) -> bool | None:
@@ -232,13 +234,18 @@ class DanfossAlly:
         return await self.get_device(device_id)
 
     async def refresh_devices(self) -> dict[str, dict[str, Any]]:
-        """Refresh all cached devices one-by-one via their dedicated endpoints."""
+        """Refresh cached devices via their dedicated endpoints."""
         device_ids = list(self.devices)
         if not device_ids:
             return await self.get_devices()
 
-        for device_id in device_ids:
-            await self.refresh_device(device_id)
+        semaphore = asyncio.Semaphore(_REFRESH_DEVICE_CONCURRENCY)
+
+        async def refresh_one(device_id: str) -> None:
+            async with semaphore:
+                await self.refresh_device(device_id)
+
+        await asyncio.gather(*(refresh_one(device_id) for device_id in device_ids))
 
         return self.devices
 

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -227,6 +227,21 @@ class DanfossAlly:
         response = await self._api.get_device_status(device_id)
         return response.get("result", [])
 
+    async def refresh_device(self, device_id: str) -> dict[str, Any] | None:
+        """Refresh one cached device via its dedicated device endpoint."""
+        return await self.get_device(device_id)
+
+    async def refresh_devices(self) -> dict[str, dict[str, Any]]:
+        """Refresh all cached devices one-by-one via their dedicated endpoints."""
+        device_ids = list(self.devices)
+        if not device_ids:
+            return await self.get_devices()
+
+        for device_id in device_ids:
+            await self.refresh_device(device_id)
+
+        return self.devices
+
     async def set_temperature(
         self,
         device_id: str,

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -1,4 +1,5 @@
 """Async-first module for handling Danfoss Ally API communication."""
+
 from __future__ import annotations
 
 import logging
@@ -38,6 +39,17 @@ _PASSTHROUGH_CODES = {
     "ctrl_alg",
     "adaptation_runstatus",
     "SetpointChangeSource",
+}
+
+_MODE_TO_SETPOINT_CODE = {
+    "at_home": "at_home_setting",
+    "home": "at_home_setting",
+    "leaving_home": "leaving_home_setting",
+    "away": "leaving_home_setting",
+    "pause": "pause_setting",
+    "manual": "manual_mode_fast",
+    "holiday": "holiday_setting",
+    "holiday_sat": "at_home_setting",
 }
 
 
@@ -83,7 +95,12 @@ def parse_device_data(device: dict[str, Any]) -> dict[str, Any]:
                 parsed["temperature"] = float(value) / 10
             elif code == "MeasuredValue" and parsed["floor_sensor"]:
                 parsed["floor_temperature"] = float(value) / 10
-            elif code in {"upper_temp", "lower_temp", "floor_temp_min", "floor_temp_max"}:
+            elif code in {
+                "upper_temp",
+                "lower_temp",
+                "floor_temp_min",
+                "floor_temp_max",
+            }:
                 parsed[code] = float(value) / 10
             elif code in {"local_temperature", "ext_measured_rs"}:
                 parsed[code] = float(value) / 100
@@ -117,6 +134,17 @@ def parse_device_data(device: dict[str, Any]) -> dict[str, Any]:
             )
 
     return parsed
+
+
+def _uses_temp_set_fallback(device: dict[str, Any]) -> bool:
+    """Return whether the device only exposes a single temp_set value."""
+    return "temp_set" in device and not {
+        "manual_mode_fast",
+        "at_home_setting",
+        "leaving_home_setting",
+        "pause_setting",
+        "holiday_setting",
+    }.issubset(device)
 
 
 class DanfossAlly:
@@ -199,6 +227,26 @@ class DanfossAlly:
         """Update temperature setpoint for one device."""
         return await self._api.set_temperature(device_id, int(temp * 10), code)
 
+    async def set_temperature_for_mode(
+        self,
+        device_id: str,
+        temp: float,
+        mode: str,
+    ) -> bool:
+        """Apply a temperature for a specific Danfoss mode."""
+        device = self.devices.get(device_id, {})
+        setpoint_code = self._get_setpoint_code_for_mode(device, mode)
+
+        mode_result = await self.set_mode(device_id, mode)
+        if mode_result is False:
+            return False
+
+        return await self.set_temperature(device_id, temp, code=setpoint_code)
+
+    async def set_manual_temperature(self, device_id: str, temp: float) -> bool:
+        """Apply a manual temperature override for one device."""
+        return await self.set_temperature_for_mode(device_id, temp, "manual")
+
     async def set_mode(self, device_id: str, mode: str) -> bool:
         """Update operating mode for one device."""
         return await self._api.set_mode(device_id, mode)
@@ -217,6 +265,13 @@ class DanfossAlly:
         device_id = device["id"]
         self.devices[device_id] = parsed
         return parsed
+
+    def _get_setpoint_code_for_mode(self, device: dict[str, Any], mode: str) -> str:
+        """Resolve the Danfoss setpoint field for one mode."""
+        if _uses_temp_set_fallback(device):
+            return "temp_set"
+
+        return _MODE_TO_SETPOINT_CODE.get(mode, "manual_mode_fast")
 
     @property
     def authorized(self) -> bool:

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -278,6 +278,35 @@ class DanfossAlly:
         """Apply a manual temperature override for one device."""
         return await self.set_temperature_for_mode(device_id, temp, "manual")
 
+    async def set_external_temperature(
+        self,
+        device_id: str,
+        temperature: float | None,
+    ) -> bool:
+        """Set an external sensor temperature and enable covered-radiator mode."""
+        temp_10 = -800 if temperature is None else int(round(temperature * 10))
+        temp_100 = -8000 if temperature is None else int(round(temperature * 100))
+        return await self.send_command(
+            device_id,
+            [
+                ("radiator_covered", True),
+                ("ext_measured_rs", temp_100),
+                ("sensor_avg_temp", temp_10),
+            ],
+        )
+
+    async def set_radiator_covered(self, device_id: str, covered: bool) -> bool:
+        """Set covered-radiator mode and clear external temperature when disabling it."""
+        commands: list[tuple[str, Any]] = [("radiator_covered", covered)]
+        if not covered:
+            commands.extend(
+                [
+                    ("ext_measured_rs", -8000),
+                    ("sensor_avg_temp", -800),
+                ]
+            )
+        return await self.send_command(device_id, commands)
+
     async def set_mode(self, device_id: str, mode: str) -> bool:
         """Update operating mode for one device."""
         return await self._api.set_mode(device_id, mode)

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -52,7 +52,7 @@ _MODE_TO_SETPOINT_CODE = {
     "holiday": "holiday_setting",
     "holiday_sat": "at_home_setting",
 }
-_REFRESH_DEVICE_CONCURRENCY = 5
+_REFRESH_DEVICE_CONCURRENCY = 10
 
 
 def _normalize_bool(value: Any) -> bool | None:

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -62,7 +62,11 @@ def _normalize_bool(value: Any) -> bool | None:
     return None
 
 
-def parse_device_data(device: dict[str, Any]) -> dict[str, Any]:
+def parse_device_data(
+    device: dict[str, Any],
+    *,
+    last_response_time: int | None = None,
+) -> dict[str, Any]:
     """Convert raw API device payloads into the library's best-effort model."""
     parsed: dict[str, Any] = {
         "isThermostat": False,
@@ -71,6 +75,8 @@ def parse_device_data(device: dict[str, Any]) -> dict[str, Any]:
         "update": device.get("update_time"),
         "floor_sensor": False,
     }
+    if last_response_time is not None:
+        parsed["last_response_time"] = last_response_time
 
     if "model" in device:
         parsed["model"] = device["model"]
@@ -195,7 +201,7 @@ class DanfossAlly:
 
         self.devices = {}
         for device in response["result"]:
-            self._store_device(device)
+            self._store_device(device, last_response_time=response.get("t"))
 
         return self.devices
 
@@ -206,7 +212,10 @@ class DanfossAlly:
             _LOGGER.error("Something went wrong loading device %s", device_id)
             return None
 
-        return self._store_device(response["result"])
+        return self._store_device(
+            response["result"],
+            last_response_time=response.get("t"),
+        )
 
     async def get_device_sub_devices(self, device_id: str) -> list[dict[str, Any]]:
         """Fetch the spec-defined sub-devices endpoint."""
@@ -259,9 +268,14 @@ class DanfossAlly:
         """Send generic commands for one device."""
         return await self._api.send_command(device_id, listofcommands)
 
-    def _store_device(self, device: dict[str, Any]) -> dict[str, Any]:
+    def _store_device(
+        self,
+        device: dict[str, Any],
+        *,
+        last_response_time: int | None = None,
+    ) -> dict[str, Any]:
         """Parse and cache one device payload."""
-        parsed = parse_device_data(device)
+        parsed = parse_device_data(device, last_response_time=last_response_time)
         device_id = device["id"]
         self.devices[device_id] = parsed
         return parsed

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -226,6 +226,36 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(await ally.set_manual_temperature("device-1", 22.5))
 
+    async def test_set_temperature_for_mode_sets_auto_mode_before_auto_setpoint(
+        self,
+    ) -> None:
+        """Mode-aware temperature writes should switch back to schedule mode."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return httpx.Response(
+                    200,
+                    json={"result": [THERMOSTAT_WITH_MODE_SETPOINTS], "t": 1},
+                )
+            if request.url.path == "/ally/devices/device-1/commands":
+                payload = json.loads(request.content.decode())
+                if payload["commands"][0] == {"code": "mode", "value": "at_home"}:
+                    return httpx.Response(201, json={"result": True, "t": 10})
+                if payload == {"commands": [{"code": "at_home_setting", "value": 210}]}:
+                    return httpx.Response(201, json={"result": True, "t": 11})
+                raise AssertionError(f"Unexpected command payload: {payload}")
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        self.assertTrue(
+            await ally.set_temperature_for_mode("device-1", 21.0, "at_home")
+        )
+
     async def test_bad_request_maps_to_domain_exception(self) -> None:
         """HTTP 400 should map to the dedicated request exception."""
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -303,6 +303,58 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(await ally.set_manual_temperature("device-1", 22.5))
 
+    async def test_set_external_temperature_enables_radiator_covered(self) -> None:
+        """External temperature writes should force covered-radiator mode."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices/device-1/commands":
+                payload = json.loads(request.content.decode())
+                self.assertEqual(
+                    payload,
+                    {
+                        "commands": [
+                            {"code": "radiator_covered", "value": True},
+                            {"code": "ext_measured_rs", "value": 2500},
+                            {"code": "sensor_avg_temp", "value": 250},
+                        ]
+                    },
+                )
+                return httpx.Response(201, json={"result": True, "t": 14})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        self.assertTrue(await ally.set_external_temperature("device-1", 25.0))
+
+    async def test_set_radiator_covered_false_clears_external_temperature(self) -> None:
+        """Disabling covered-radiator mode should clear external sensor values."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices/device-1/commands":
+                payload = json.loads(request.content.decode())
+                self.assertEqual(
+                    payload,
+                    {
+                        "commands": [
+                            {"code": "radiator_covered", "value": False},
+                            {"code": "ext_measured_rs", "value": -8000},
+                            {"code": "sensor_avg_temp", "value": -800},
+                        ]
+                    },
+                )
+                return httpx.Response(201, json={"result": True, "t": 15})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        self.assertTrue(await ally.set_radiator_covered("device-1", False))
+
     async def test_set_temperature_for_mode_sets_auto_mode_before_auto_setpoint(
         self,
     ) -> None:

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -31,6 +31,23 @@ DEVICE_PAYLOAD = {
     ],
 }
 
+THERMOSTAT_WITH_MODE_SETPOINTS = {
+    **DEVICE_PAYLOAD,
+    "status": [
+        {"code": "manual_mode_fast", "value": 215},
+        {"code": "at_home_setting", "value": 200},
+        {"code": "leaving_home_setting", "value": 170},
+        {"code": "pause_setting", "value": 70},
+        {"code": "holiday_setting", "value": 140},
+        {"code": "temp_current", "value": 203},
+        {"code": "humidity_value", "value": 455},
+        {"code": "battery_percentage", "value": 97},
+        {"code": "window_state", "value": "open"},
+        {"code": "switch_state", "value": "true"},
+        {"code": "mode", "value": "manual"},
+    ],
+}
+
 
 class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
     """Exercise the async-first client stack."""
@@ -150,6 +167,64 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         await ally.initialize("key", "secret")
 
         self.assertTrue(await ally.set_temperature("device-1", 22.0, code="temp_set"))
+
+    async def test_set_temperature_for_mode_sets_mode_before_mode_setpoint(
+        self,
+    ) -> None:
+        """Mode-aware temperature writes should set the matching mode first."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return httpx.Response(
+                    200,
+                    json={"result": [THERMOSTAT_WITH_MODE_SETPOINTS], "t": 1},
+                )
+            if request.url.path == "/ally/devices/device-1/commands":
+                payload = json.loads(request.content.decode())
+                if payload == {"commands": [{"code": "mode", "value": "manual"}]}:
+                    return httpx.Response(201, json={"result": True, "t": 6})
+                if payload == {
+                    "commands": [{"code": "manual_mode_fast", "value": 230}]
+                }:
+                    return httpx.Response(201, json={"result": True, "t": 7})
+                raise AssertionError(f"Unexpected command payload: {payload}")
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        self.assertTrue(await ally.set_temperature_for_mode("device-1", 23.0, "manual"))
+
+    async def test_set_manual_temperature_is_manual_mode_helper(self) -> None:
+        """Manual temperature helper should reuse manual mode semantics."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return httpx.Response(
+                    200,
+                    json={"result": [THERMOSTAT_WITH_MODE_SETPOINTS], "t": 1},
+                )
+            if request.url.path == "/ally/devices/device-1/commands":
+                payload = json.loads(request.content.decode())
+                if payload == {"commands": [{"code": "mode", "value": "manual"}]}:
+                    return httpx.Response(201, json={"result": True, "t": 8})
+                if payload == {
+                    "commands": [{"code": "manual_mode_fast", "value": 225}]
+                }:
+                    return httpx.Response(201, json={"result": True, "t": 9})
+                raise AssertionError(f"Unexpected command payload: {payload}")
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        self.assertTrue(await ally.set_manual_temperature("device-1", 22.5))
 
     async def test_bad_request_maps_to_domain_exception(self) -> None:
         """HTTP 400 should map to the dedicated request exception."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import unittest
 from unittest.mock import patch
@@ -182,6 +183,30 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(device["temp_set"], 23.0)
         self.assertEqual(device["temperature"], 20.5)
         self.assertEqual(device["last_response_time"], 13)
+
+    async def test_refresh_devices_limits_parallelism_to_five(self) -> None:
+        """Cached device refreshes should use bounded parallelism."""
+        ally = DanfossAlly(
+            api=await self._make_api(lambda request: httpx.Response(200))
+        )
+        ally.devices = {f"device-{idx}": {"id": f"device-{idx}"} for idx in range(8)}
+
+        active_calls = 0
+        max_active_calls = 0
+
+        async def fake_refresh_device(device_id: str) -> dict[str, object]:
+            nonlocal active_calls, max_active_calls
+            active_calls += 1
+            max_active_calls = max(max_active_calls, active_calls)
+            await asyncio.sleep(0)
+            active_calls -= 1
+            return {"id": device_id}
+
+        ally.refresh_device = fake_refresh_device  # type: ignore[method-assign]
+
+        await ally.refresh_devices()
+
+        self.assertEqual(max_active_calls, 5)
 
     async def test_send_command_accepts_result_shape(self) -> None:
         """Command responses with a result field should be accepted."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -184,7 +184,7 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(device["temperature"], 20.5)
         self.assertEqual(device["last_response_time"], 13)
 
-    async def test_refresh_devices_limits_parallelism_to_five(self) -> None:
+    async def test_refresh_devices_limits_parallelism_to_ten(self) -> None:
         """Cached device refreshes should use bounded parallelism."""
         ally = DanfossAlly(
             api=await self._make_api(lambda request: httpx.Response(200))
@@ -206,7 +206,7 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         await ally.refresh_devices()
 
-        self.assertEqual(max_active_calls, 5)
+        self.assertEqual(max_active_calls, 8)
 
     async def test_send_command_accepts_result_shape(self) -> None:
         """Command responses with a result field should be accepted."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -103,6 +103,25 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(devices["device-1"]["name"], "Living room")
         self.assertEqual(devices["device-1"]["temperature"], 20.3)
         self.assertTrue(devices["device-1"]["window_open"])
+        self.assertEqual(devices["device-1"]["last_response_time"], 1)
+
+    async def test_get_device_maps_last_response_time(self) -> None:
+        """Single-device reads should keep the API response timestamp."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices/device-1":
+                return httpx.Response(200, json={"result": DEVICE_PAYLOAD, "t": 12})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        device = await ally.get_device("device-1")
+
+        assert device is not None
+        self.assertEqual(device["last_response_time"], 12)
 
     async def test_get_device_status_and_sub_devices(self) -> None:
         """Spec-defined read-only endpoints should be available."""
@@ -305,3 +324,9 @@ class ParseDeviceDataTests(unittest.TestCase):
         self.assertTrue(parsed["switch_state"])
         self.assertEqual(parsed["mode"], "manual")
         self.assertTrue(parsed["isThermostat"])
+
+    def test_parse_device_data_accepts_last_response_time(self) -> None:
+        """The parser should expose the API response timestamp when provided."""
+        parsed = parse_device_data(DEVICE_PAYLOAD, last_response_time=1773499838298)
+
+        self.assertEqual(parsed["last_response_time"], 1773499838298)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -150,6 +150,39 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(status[0]["code"], "temp_set")
         self.assertEqual(sub_devices[0]["id"], "child-1")
 
+    async def test_refresh_device_uses_single_device_endpoint(self) -> None:
+        """Per-device refresh should only use the single-device payload."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices/device-1":
+                return httpx.Response(
+                    200,
+                    json={
+                        "result": {
+                            **DEVICE_PAYLOAD,
+                            "status": [
+                                {"code": "temp_set", "value": 230},
+                                {"code": "temp_current", "value": 205},
+                                {"code": "mode", "value": "manual"},
+                            ],
+                        },
+                        "t": 13,
+                    },
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        device = await ally.refresh_device("device-1")
+
+        assert device is not None
+        self.assertEqual(device["temp_set"], 23.0)
+        self.assertEqual(device["temperature"], 20.5)
+        self.assertEqual(device["last_response_time"], 13)
+
     async def test_send_command_accepts_result_shape(self) -> None:
         """Command responses with a result field should be accepted."""
 


### PR DESCRIPTION
Summary
- add Danfoss-specific helpers for mode-aware thermostat writes
- support manual temperature overrides and preset/setpoint writes in the library instead of each consumer reimplementing them

Changes
- add mode-to-setpoint resolution helpers to the async client wrapper
- add set_temperature_for_mode() and set_manual_temperature() helpers
- keep temp_set fallback for older device payloads
- add async tests covering the new write flows

Testing
- python -m pytest -q tests/test_async_client.py
- ruff check pydanfossally/__init__.py tests/test_async_client.py
- ruff format pydanfossally/__init__.py tests/test_async_client.py

Notes
- this is intended for integrations that need Danfoss-specific write semantics without duplicating mode/setpoint orchestration
- built on top of the already-merged lazy client initialization work