### PR TITLE
Use trusted publisher for PyPI releases

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -5,6 +5,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -24,8 +28,4 @@ jobs:
           poetry build
 
       - name: Publish
-        run: |
-          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-          poetry publish
-
-      # NOTE: Make sure you have added PYPI_API_TOKEN repository secret
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
Switch PyPI publishing from a stored API token to PyPI Trusted Publisher via GitHub Actions OIDC.

## Changes
- add the workflow permissions required for OIDC publishing
- replace token-based poetry publish with pypa/gh-action-pypi-publish
- remove the workflow dependency on the PYPI_TOKEN repository secret

## Testing
- reviewed the updated GitHub Actions workflow configuration
- confirmed there are no remaining PYPI_TOKEN references in repository workflow files

## Notes
- after merge, the old PyPI API token can be deleted from PyPI
- after merge, the PYPI_TOKEN GitHub Actions secret can be removed if it still exists
