### PR TITLE
Support skip-changelog in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,8 @@ name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 change-template: '- #$NUMBER $TITLE @$AUTHOR'
 sort-direction: ascending
+exclude-labels:
+  - 'skip-changelog'
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
## Summary
Teach Release Drafter to omit pull requests labeled skip-changelog from generated release notes.

## Changes
- add `exclude-labels` support for the `skip-changelog` label in Release Drafter config
- keep existing category and version resolver behavior unchanged

## Testing
- reviewed the Release Drafter configuration change
- verified the config now excludes PRs labeled `skip-changelog` from generated draft notes

## Notes
- this only changes draft release generation; it does not affect tagging or publishing
