### PR TITLE
Make device refresh throttling configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ client alive and reuse it across many calls.
 ```python
 from pydanfossally import DanfossAlly
 
-ally = DanfossAlly(timeout=30)
+ally = DanfossAlly(
+    timeout=30,
+    refresh_device_concurrency=3,
+    refresh_device_min_interval=0.35,
+)
 
 authorized = await ally.initialize(key, secret)
 if not authorized:
@@ -45,7 +49,11 @@ from pydanfossally import DanfossAlly
 
 
 async def main() -> None:
-    async with DanfossAlly(timeout=30) as ally:
+    async with DanfossAlly(
+        timeout=30,
+        refresh_device_concurrency=3,
+        refresh_device_min_interval=0.35,
+    ) as ally:
         authorized = await ally.initialize(os.environ["KEY"], os.environ["SECRET"])
         if not authorized:
             raise RuntimeError("Authorization failed")
@@ -86,6 +94,18 @@ device-specific status or command codes. That means:
   accepts both `{"result": true, "t": ...}` and `{"t": ...}`.
 - Live verification should be performed against read-only endpoints before enabling write flows
   in production integrations.
+
+## Refresh behavior
+
+The library keeps `refresh_device()` on the near-realtime `GET /ally/devices/{device_id}`
+endpoint. Bulk `refresh_devices()` calls intentionally pace those per-device reads and use a
+small concurrency limit to reduce burst load against the upstream API.
+
+Both knobs are configurable through `DanfossAlly(...)`:
+
+- `refresh_device_concurrency` controls how many per-device refreshes may run at once
+- `refresh_device_min_interval` controls the minimum delay in seconds between starting two
+  per-device refreshes
 
 ## Local verification
 

--- a/example.py
+++ b/example.py
@@ -11,7 +11,10 @@ from pydanfossally import DanfossAlly
 
 async def main() -> None:
     """Run a simple read-only session against the Danfoss Ally API."""
-    async with DanfossAlly() as ally:
+    async with DanfossAlly(
+        refresh_device_concurrency=3,
+        refresh_device_min_interval=0.35,
+    ) as ally:
         authorized = await ally.initialize(environ["KEY"], environ["SECRET"])
         if not authorized:
             raise RuntimeError("Error in authorization")

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -52,7 +52,8 @@ _MODE_TO_SETPOINT_CODE = {
     "holiday": "holiday_setting",
     "holiday_sat": "at_home_setting",
 }
-_REFRESH_DEVICE_CONCURRENCY = 10
+_REFRESH_DEVICE_CONCURRENCY = 3
+_REFRESH_DEVICE_MIN_INTERVAL = 0.35
 
 
 def _normalize_bool(value: Any) -> bool | None:
@@ -162,12 +163,23 @@ class DanfossAlly:
         self,
         api: DanfossAllyAPI | None = None,
         timeout: float = DEFAULT_TIMEOUT,
+        refresh_device_concurrency: int = _REFRESH_DEVICE_CONCURRENCY,
+        refresh_device_min_interval: float = _REFRESH_DEVICE_MIN_INTERVAL,
     ) -> None:
         """Initialize the connector."""
+        if refresh_device_concurrency < 1:
+            raise ValueError("refresh_device_concurrency must be at least 1")
+        if refresh_device_min_interval < 0:
+            raise ValueError("refresh_device_min_interval must be non-negative")
+
         self._authorized = False
         self._token: str | None = None
         self.devices: dict[str, dict[str, Any]] = {}
         self._api = api or DanfossAllyAPI(timeout=timeout)
+        self._refresh_device_concurrency = refresh_device_concurrency
+        self._refresh_device_min_interval = refresh_device_min_interval
+        self._refresh_rate_lock = asyncio.Lock()
+        self._next_refresh_slot = 0.0
 
     async def __aenter__(self) -> DanfossAlly:
         """Allow async context manager usage."""
@@ -233,16 +245,30 @@ class DanfossAlly:
         """Refresh one cached device via its dedicated device endpoint."""
         return await self.get_device(device_id)
 
+    async def _wait_for_refresh_slot(self) -> None:
+        """Space refreshes out so the API does not receive a burst of device reads."""
+        loop = asyncio.get_running_loop()
+
+        async with self._refresh_rate_lock:
+            now = loop.time()
+            scheduled_at = max(now, self._next_refresh_slot)
+            self._next_refresh_slot = scheduled_at + self._refresh_device_min_interval
+
+        delay = scheduled_at - loop.time()
+        if delay > 0:
+            await asyncio.sleep(delay)
+
     async def refresh_devices(self) -> dict[str, dict[str, Any]]:
         """Refresh cached devices via their dedicated endpoints."""
         device_ids = list(self.devices)
         if not device_ids:
             return await self.get_devices()
 
-        semaphore = asyncio.Semaphore(_REFRESH_DEVICE_CONCURRENCY)
+        semaphore = asyncio.Semaphore(self._refresh_device_concurrency)
 
         async def refresh_one(device_id: str) -> None:
             async with semaphore:
+                await self._wait_for_refresh_slot()
                 await self.refresh_device(device_id)
 
         await asyncio.gather(*(refresh_one(device_id) for device_id in device_ids))

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -184,12 +184,14 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(device["temperature"], 20.5)
         self.assertEqual(device["last_response_time"], 13)
 
-    async def test_refresh_devices_limits_parallelism_to_ten(self) -> None:
+    async def test_refresh_devices_limits_parallelism_to_three(self) -> None:
         """Cached device refreshes should use bounded parallelism."""
         ally = DanfossAlly(
-            api=await self._make_api(lambda request: httpx.Response(200))
+            api=await self._make_api(lambda request: httpx.Response(200)),
+            refresh_device_concurrency=3,
+            refresh_device_min_interval=0,
         )
-        ally.devices = {f"device-{idx}": {"id": f"device-{idx}"} for idx in range(8)}
+        ally.devices = {f"device-{idx}": {"id": f"device-{idx}"} for idx in range(6)}
 
         active_calls = 0
         max_active_calls = 0
@@ -206,7 +208,37 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         await ally.refresh_devices()
 
-        self.assertEqual(max_active_calls, 8)
+        self.assertEqual(max_active_calls, 3)
+
+    async def test_refresh_devices_rate_limits_device_reads(self) -> None:
+        """Cached device refreshes should be paced to avoid request bursts."""
+        ally = DanfossAlly(
+            api=await self._make_api(lambda request: httpx.Response(200)),
+            refresh_device_min_interval=0.02,
+        )
+        ally.devices = {f"device-{idx}": {"id": f"device-{idx}"} for idx in range(3)}
+
+        started_at: list[float] = []
+
+        async def fake_refresh_device(device_id: str) -> dict[str, object]:
+            started_at.append(asyncio.get_running_loop().time())
+            return {"id": device_id}
+
+        ally.refresh_device = fake_refresh_device  # type: ignore[method-assign]
+
+        await ally.refresh_devices()
+
+        self.assertEqual(len(started_at), 3)
+        self.assertGreaterEqual(started_at[1] - started_at[0], 0.015)
+        self.assertGreaterEqual(started_at[2] - started_at[1], 0.015)
+
+    def test_constructor_rejects_invalid_refresh_tuning(self) -> None:
+        """Refresh tuning should reject invalid values early."""
+        with self.assertRaises(ValueError):
+            DanfossAlly(refresh_device_concurrency=0)
+
+        with self.assertRaises(ValueError):
+            DanfossAlly(refresh_device_min_interval=-0.1)
 
     async def test_send_command_accepts_result_shape(self) -> None:
         """Command responses with a result field should be accepted."""


### PR DESCRIPTION
## Summary
- make per-device refresh throttling configurable from the DanfossAlly constructor
- reduce the default refresh burst size while keeping near-realtime device reads

## Changes
- lower the default device refresh concurrency from 10 to 3
- add a minimum interval between starting per-device refresh requests
- expose refresh tuning through  and 
- validate invalid refresh tuning values early
- document the new options and cover them with tests

## Testing
- ...................                                                      [100%]
19 passed in 0.18s

## Notes
-  still uses  for near-realtime data
-  now spreads requests out to be gentler on the upstream API
