### PR TITLE
Handle common Danfoss Ally HTTP API errors explicitly

### DIFF
--- a/pydanfossally/danfossallyapi.py
+++ b/pydanfossally/danfossallyapi.py
@@ -13,6 +13,7 @@ import httpx
 from .exceptions import (
     APIError,
     BadRequestError,
+    ForbiddenError,
     InternalServerError,
     NotFoundError,
     RateLimitError,
@@ -144,11 +145,13 @@ class DanfossAllyAPI:
             return BadRequestError()
         if status_code == 401:
             return UnauthorizedError()
+        if status_code == 403:
+            return ForbiddenError()
         if status_code == 404:
             return NotFoundError()
         if status_code == 429:
             return RateLimitError()
-        if status_code == 500:
+        if 500 <= status_code <= 599:
             return InternalServerError()
         return APIError(f"Unexpected HTTP status code: {status_code}")
 

--- a/pydanfossally/exceptions.py
+++ b/pydanfossally/exceptions.py
@@ -11,6 +11,10 @@ class BadRequestError(APIError):
     """Raised when the API rejects the request payload."""
 
 
+class ForbiddenError(APIError):
+    """Raised when the API refuses access to the requested resource."""
+
+
 class RateLimitError(APIError):
     """Raised when the API throttles requests."""
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -11,7 +11,12 @@ import httpx
 
 from pydanfossally import DanfossAlly, parse_device_data
 from pydanfossally.danfossallyapi import API_HOST, DanfossAllyAPI
-from pydanfossally.exceptions import BadRequestError, RateLimitError
+from pydanfossally.exceptions import (
+    BadRequestError,
+    ForbiddenError,
+    InternalServerError,
+    RateLimitError,
+)
 
 
 TOKEN_RESPONSE = {"access_token": "token-123", "expires_in": 3600}
@@ -447,6 +452,38 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         await ally.initialize("key", "secret")
 
         with self.assertRaises(RateLimitError):
+            await ally.get_devices()
+
+    async def test_forbidden_maps_to_domain_exception(self) -> None:
+        """HTTP 403 should map to the dedicated forbidden exception."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return httpx.Response(403, json={"title": "Forbidden"})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        with self.assertRaises(ForbiddenError):
+            await ally.get_devices()
+
+    async def test_server_error_range_maps_to_domain_exception(self) -> None:
+        """HTTP 5xx responses should map to the dedicated server exception."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return httpx.Response(503, json={"title": "Service Unavailable"})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        with self.assertRaises(InternalServerError):
             await ally.get_devices()
 
 


### PR DESCRIPTION
## Summary
- add explicit exception handling for common HTTP API errors, including HTTP 403
- map the full HTTP 5xx range to the existing server error exception
- add async client coverage for forbidden and server-side error mappings

## Test strategy
- `PYTHONPATH=/development/github/homeassistant/pydanfossally pytest tests/test_async_client.py`
- `ruff check pydanfossally tests`

## Known limitations
- unexpected HTTP status codes outside the explicit mappings still fall back to `APIError`
- retry behavior is handled in the Home Assistant integration, not in this module

## Configuration changes
- none
