### PR TITLE
Sync pending device refreshes with bulk updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ from pydanfossally import DanfossAlly
 
 ally = DanfossAlly(
     timeout=30,
-    refresh_device_concurrency=3,
+    refresh_device_concurrency=2,
     refresh_device_min_interval=0.35,
+    refresh_device_timeout=600,
 )
 
 authorized = await ally.initialize(key, secret)
@@ -51,8 +52,9 @@ from pydanfossally import DanfossAlly
 async def main() -> None:
     async with DanfossAlly(
         timeout=30,
-        refresh_device_concurrency=3,
+        refresh_device_concurrency=2,
         refresh_device_min_interval=0.35,
+        refresh_device_timeout=600,
     ) as ally:
         authorized = await ally.initialize(os.environ["KEY"], os.environ["SECRET"])
         if not authorized:
@@ -97,15 +99,18 @@ device-specific status or command codes. That means:
 
 ## Refresh behavior
 
-The library keeps `refresh_device()` on the near-realtime `GET /ally/devices/{device_id}`
-endpoint. Bulk `refresh_devices()` calls intentionally pace those per-device reads and use a
-small concurrency limit to reduce burst load against the upstream API.
+The library uses `GET /ally/devices` as its baseline refresh path. After a successful local
+write, the affected device temporarily stays on the near-realtime
+`GET /ally/devices/{device_id}` endpoint until the bulk endpoint reflects the written fields or a
+timeout is reached.
 
 Both knobs are configurable through `DanfossAlly(...)`:
 
 - `refresh_device_concurrency` controls how many per-device refreshes may run at once
 - `refresh_device_min_interval` controls the minimum delay in seconds between starting two
   per-device refreshes
+- `refresh_device_timeout` controls how long a written device may stay on per-device refresh
+  before the client falls back to the bulk endpoint only
 
 ## Local verification
 

--- a/example.py
+++ b/example.py
@@ -12,8 +12,9 @@ from pydanfossally import DanfossAlly
 async def main() -> None:
     """Run a simple read-only session against the Danfoss Ally API."""
     async with DanfossAlly(
-        refresh_device_concurrency=3,
+        refresh_device_concurrency=2,
         refresh_device_min_interval=0.35,
+        refresh_device_timeout=600,
     ) as ally:
         authorized = await ally.initialize(environ["KEY"], environ["SECRET"])
         if not authorized:

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import logging
 from typing import Any
 
@@ -52,8 +53,17 @@ _MODE_TO_SETPOINT_CODE = {
     "holiday": "holiday_setting",
     "holiday_sat": "at_home_setting",
 }
-_REFRESH_DEVICE_CONCURRENCY = 3
+_REFRESH_DEVICE_CONCURRENCY = 2
 _REFRESH_DEVICE_MIN_INTERVAL = 0.35
+_REFRESH_DEVICE_TIMEOUT = 600.0
+
+
+@dataclass
+class _PendingDeviceSync:
+    """Track one device that should keep using realtime refresh temporarily."""
+
+    expected_fields: dict[str, Any]
+    deadline: float
 
 
 def _normalize_bool(value: Any) -> bool | None:
@@ -165,12 +175,15 @@ class DanfossAlly:
         timeout: float = DEFAULT_TIMEOUT,
         refresh_device_concurrency: int = _REFRESH_DEVICE_CONCURRENCY,
         refresh_device_min_interval: float = _REFRESH_DEVICE_MIN_INTERVAL,
+        refresh_device_timeout: float = _REFRESH_DEVICE_TIMEOUT,
     ) -> None:
         """Initialize the connector."""
         if refresh_device_concurrency < 1:
             raise ValueError("refresh_device_concurrency must be at least 1")
         if refresh_device_min_interval < 0:
             raise ValueError("refresh_device_min_interval must be non-negative")
+        if refresh_device_timeout < 0:
+            raise ValueError("refresh_device_timeout must be non-negative")
 
         self._authorized = False
         self._token: str | None = None
@@ -178,8 +191,11 @@ class DanfossAlly:
         self._api = api or DanfossAllyAPI(timeout=timeout)
         self._refresh_device_concurrency = refresh_device_concurrency
         self._refresh_device_min_interval = refresh_device_min_interval
+        self._refresh_device_timeout = refresh_device_timeout
         self._refresh_rate_lock = asyncio.Lock()
         self._next_refresh_slot = 0.0
+        self._pending_device_syncs: dict[str, _PendingDeviceSync] = {}
+        self._last_bulk_response_time: int | None = None
 
     async def __aenter__(self) -> DanfossAlly:
         """Allow async context manager usage."""
@@ -213,9 +229,19 @@ class DanfossAlly:
             _LOGGER.error("Something went wrong loading devices")
             return self.devices
 
+        previous_bulk_response_time = self._last_bulk_response_time
+        current_bulk_response_time = response.get("t")
+
         self.devices = {}
         for device in response["result"]:
             self._store_device(device, last_response_time=response.get("t"))
+
+        self._last_bulk_response_time = current_bulk_response_time
+        if (
+            current_bulk_response_time is None
+            or current_bulk_response_time != previous_bulk_response_time
+        ):
+            self._clear_pending_device_syncs_from_bulk_snapshot()
 
         return self.devices
 
@@ -259,10 +285,12 @@ class DanfossAlly:
             await asyncio.sleep(delay)
 
     async def refresh_devices(self) -> dict[str, dict[str, Any]]:
-        """Refresh cached devices via their dedicated endpoints."""
-        device_ids = list(self.devices)
+        """Refresh the bulk snapshot, then keep pending devices on the realtime path."""
+        await self.get_devices()
+
+        device_ids = self._active_pending_device_ids()
         if not device_ids:
-            return await self.get_devices()
+            return self.devices
 
         semaphore = asyncio.Semaphore(self._refresh_device_concurrency)
 
@@ -282,7 +310,7 @@ class DanfossAlly:
         code: str = "manual_mode_fast",
     ) -> bool:
         """Update temperature setpoint for one device."""
-        return await self._api.set_temperature(device_id, int(temp * 10), code)
+        return await self.send_command(device_id, [(code, int(temp * 10))])
 
     async def set_temperature_for_mode(
         self,
@@ -335,7 +363,10 @@ class DanfossAlly:
 
     async def set_mode(self, device_id: str, mode: str) -> bool:
         """Update operating mode for one device."""
-        return await self._api.set_mode(device_id, mode)
+        result = await self._api.set_mode(device_id, mode)
+        if result:
+            self._mark_pending_device_sync(device_id, {"mode": mode})
+        return result
 
     async def send_command(
         self,
@@ -343,7 +374,13 @@ class DanfossAlly:
         listofcommands: list[tuple[str, Any]],
     ) -> bool:
         """Send generic commands for one device."""
-        return await self._api.send_command(device_id, listofcommands)
+        result = await self._api.send_command(device_id, listofcommands)
+        if result:
+            self._mark_pending_device_sync(
+                device_id,
+                self._expected_fields_from_commands(listofcommands),
+            )
+        return result
 
     def _store_device(
         self,
@@ -363,6 +400,80 @@ class DanfossAlly:
             return "temp_set"
 
         return _MODE_TO_SETPOINT_CODE.get(mode, "manual_mode_fast")
+
+    def _active_pending_device_ids(self) -> list[str]:
+        """Return pending devices that have not yet timed out."""
+        now = asyncio.get_running_loop().time()
+        expired_device_ids = [
+            device_id
+            for device_id, pending_sync in self._pending_device_syncs.items()
+            if pending_sync.deadline <= now
+        ]
+        for device_id in expired_device_ids:
+            self._pending_device_syncs.pop(device_id, None)
+        return list(self._pending_device_syncs)
+
+    def _clear_pending_device_syncs_from_bulk_snapshot(self) -> None:
+        """Stop realtime refresh once the bulk endpoint has caught up."""
+        satisfied_device_ids = [
+            device_id
+            for device_id, pending_sync in self._pending_device_syncs.items()
+            if self._device_matches_expected_fields(
+                self.devices.get(device_id, {}),
+                pending_sync.expected_fields,
+            )
+        ]
+        for device_id in satisfied_device_ids:
+            self._pending_device_syncs.pop(device_id, None)
+
+    def _mark_pending_device_sync(
+        self,
+        device_id: str,
+        expected_fields: dict[str, Any],
+    ) -> None:
+        """Track one device until the bulk endpoint reflects the written fields."""
+        if not expected_fields:
+            return
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._refresh_device_timeout
+        current = self._pending_device_syncs.get(device_id)
+        merged_fields = dict(current.expected_fields) if current else {}
+        merged_fields.update(expected_fields)
+        self._pending_device_syncs[device_id] = _PendingDeviceSync(
+            expected_fields=merged_fields,
+            deadline=deadline,
+        )
+
+    def _expected_fields_from_commands(
+        self,
+        commands: list[tuple[str, Any]],
+    ) -> dict[str, Any]:
+        """Map write commands onto parsed device fields used for bulk-sync matching."""
+        expected_fields: dict[str, Any] = {}
+        for code, value in commands:
+            if code in _SETPOINT_CODES:
+                expected_fields[code] = float(value) / 10
+            elif code == "mode":
+                expected_fields["mode"] = value
+            elif code == "sensor_avg_temp":
+                expected_fields["external_sensor_temperature"] = float(value) / 10
+            elif code in {"local_temperature", "ext_measured_rs"}:
+                expected_fields[code] = float(value) / 100
+            elif code in _BOOLEAN_CODES:
+                normalized = _normalize_bool(value)
+                expected_fields[code.lower()] = value if normalized is None else normalized
+            elif code in _PASSTHROUGH_CODES:
+                expected_fields[code.lower()] = value
+        return expected_fields
+
+    def _device_matches_expected_fields(
+        self,
+        device: dict[str, Any],
+        expected_fields: dict[str, Any],
+    ) -> bool:
+        """Return whether the parsed bulk device state reflects the expected fields."""
+        return all(device.get(field) == value for field, value in expected_fields.items())
 
     @property
     def authorized(self) -> bool:

--- a/pydanfossally/danfossallyapi.py
+++ b/pydanfossally/danfossallyapi.py
@@ -13,6 +13,7 @@ import httpx
 from .exceptions import (
     APIError,
     BadRequestError,
+    ForbiddenError,
     InternalServerError,
     NotFoundError,
     RateLimitError,
@@ -144,11 +145,13 @@ class DanfossAllyAPI:
             return BadRequestError()
         if status_code == 401:
             return UnauthorizedError()
+        if status_code == 403:
+            return ForbiddenError()
         if status_code == 404:
             return NotFoundError()
         if status_code == 429:
             return RateLimitError()
-        if status_code == 500:
+        if 500 <= status_code <= 599:
             return InternalServerError()
         return APIError(f"Unexpected HTTP status code: {status_code}")
 

--- a/pydanfossally/exceptions.py
+++ b/pydanfossally/exceptions.py
@@ -11,6 +11,10 @@ class BadRequestError(APIError):
     """Raised when the API rejects the request payload."""
 
 
+class ForbiddenError(APIError):
+    """Raised when the API refuses access to the requested resource."""
+
+
 class RateLimitError(APIError):
     """Raised when the API throttles requests."""
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -11,7 +11,12 @@ import httpx
 
 from pydanfossally import DanfossAlly, parse_device_data
 from pydanfossally.danfossallyapi import API_HOST, DanfossAllyAPI
-from pydanfossally.exceptions import BadRequestError, RateLimitError
+from pydanfossally.exceptions import (
+    BadRequestError,
+    ForbiddenError,
+    InternalServerError,
+    RateLimitError,
+)
 
 
 TOKEN_RESPONSE = {"access_token": "token-123", "expires_in": 3600}
@@ -447,6 +452,38 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         await ally.initialize("key", "secret")
 
         with self.assertRaises(RateLimitError):
+            await ally.get_devices()
+
+    async def test_forbidden_maps_to_domain_exception(self) -> None:
+        """HTTP 403 should map to the dedicated forbidden exception."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return httpx.Response(403, json={"title": "Forbidden"})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        with self.assertRaises(ForbiddenError):
+            await ally.get_devices()
+
+    async def test_server_error_range_maps_to_domain_exception(self) -> None:
+        """HTTP 5xx responses should map to the dedicated server exception."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return httpx.Response(503, json={"title": "Service Unavailable"})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        with self.assertRaises(InternalServerError):
             await ally.get_devices()
 
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -189,14 +189,18 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(device["temperature"], 20.5)
         self.assertEqual(device["last_response_time"], 13)
 
-    async def test_refresh_devices_limits_parallelism_to_three(self) -> None:
-        """Cached device refreshes should use bounded parallelism."""
+    async def test_refresh_devices_limits_parallelism_to_two_for_pending_devices(
+        self,
+    ) -> None:
+        """Pending device refreshes should use bounded parallelism."""
         ally = DanfossAlly(
             api=await self._make_api(lambda request: httpx.Response(200)),
-            refresh_device_concurrency=3,
+            refresh_device_concurrency=2,
             refresh_device_min_interval=0,
         )
         ally.devices = {f"device-{idx}": {"id": f"device-{idx}"} for idx in range(6)}
+        for idx in range(4):
+            ally._mark_pending_device_sync(f"device-{idx}", {"mode": "manual"})
 
         active_calls = 0
         max_active_calls = 0
@@ -209,19 +213,25 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             active_calls -= 1
             return {"id": device_id}
 
+        async def fake_get_devices() -> dict[str, dict[str, object]]:
+            return ally.devices
+
+        ally.get_devices = fake_get_devices  # type: ignore[method-assign]
         ally.refresh_device = fake_refresh_device  # type: ignore[method-assign]
 
         await ally.refresh_devices()
 
-        self.assertEqual(max_active_calls, 3)
+        self.assertEqual(max_active_calls, 2)
 
-    async def test_refresh_devices_rate_limits_device_reads(self) -> None:
-        """Cached device refreshes should be paced to avoid request bursts."""
+    async def test_refresh_devices_rate_limits_pending_device_reads(self) -> None:
+        """Pending device refreshes should be paced to avoid request bursts."""
         ally = DanfossAlly(
             api=await self._make_api(lambda request: httpx.Response(200)),
             refresh_device_min_interval=0.02,
         )
         ally.devices = {f"device-{idx}": {"id": f"device-{idx}"} for idx in range(3)}
+        for idx in range(3):
+            ally._mark_pending_device_sync(f"device-{idx}", {"mode": "manual"})
 
         started_at: list[float] = []
 
@@ -229,6 +239,10 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             started_at.append(asyncio.get_running_loop().time())
             return {"id": device_id}
 
+        async def fake_get_devices() -> dict[str, dict[str, object]]:
+            return ally.devices
+
+        ally.get_devices = fake_get_devices  # type: ignore[method-assign]
         ally.refresh_device = fake_refresh_device  # type: ignore[method-assign]
 
         await ally.refresh_devices()
@@ -237,6 +251,106 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertGreaterEqual(started_at[1] - started_at[0], 0.015)
         self.assertGreaterEqual(started_at[2] - started_at[1], 0.015)
 
+    async def test_refresh_devices_only_hot_refreshes_pending_devices_until_bulk_catches_up(
+        self,
+    ) -> None:
+        """Bulk refresh should stay the baseline until a pending write is reflected there."""
+        bulk_calls = 0
+        device_calls = 0
+
+        updated_device = {
+            **DEVICE_PAYLOAD,
+            "status": [
+                {"code": "temp_set", "value": 220},
+                {"code": "temp_current", "value": 203},
+                {"code": "humidity_value", "value": 455},
+                {"code": "battery_percentage", "value": 97},
+                {"code": "window_state", "value": "open"},
+                {"code": "switch_state", "value": "true"},
+                {"code": "mode", "value": "manual"},
+            ],
+        }
+        other_device = {
+            **DEVICE_PAYLOAD,
+            "id": "device-2",
+            "name": " Bedroom ",
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal bulk_calls, device_calls
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                bulk_calls += 1
+                if bulk_calls <= 2:
+                    return httpx.Response(
+                        200,
+                        json={"result": [DEVICE_PAYLOAD, other_device], "t": 1},
+                    )
+                return httpx.Response(
+                    200,
+                    json={"result": [updated_device, other_device], "t": 2},
+                )
+            if request.url.path == "/ally/devices/device-1/commands":
+                return httpx.Response(201, json={"result": True, "t": 5})
+            if request.url.path == "/ally/devices/device-1":
+                device_calls += 1
+                return httpx.Response(200, json={"result": updated_device, "t": 6})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(
+            api=await self._make_api(handler),
+            refresh_device_min_interval=0,
+        )
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        self.assertTrue(await ally.set_temperature("device-1", 22.0, code="temp_set"))
+        self.assertIn("device-1", ally._pending_device_syncs)
+
+        await ally.refresh_devices()
+
+        self.assertEqual(bulk_calls, 2)
+        self.assertEqual(device_calls, 1)
+        self.assertEqual(ally.devices["device-1"]["temp_set"], 22.0)
+        self.assertIn("device-1", ally._pending_device_syncs)
+
+        await ally.refresh_devices()
+
+        self.assertEqual(bulk_calls, 3)
+        self.assertEqual(device_calls, 1)
+        self.assertNotIn("device-1", ally._pending_device_syncs)
+
+    async def test_refresh_devices_drops_pending_device_after_timeout(self) -> None:
+        """Pending realtime refresh should stop once the per-device timeout is reached."""
+        ally = DanfossAlly(
+            api=await self._make_api(lambda request: httpx.Response(200)),
+            refresh_device_min_interval=0,
+        )
+        ally.devices = {"device-1": {"id": "device-1"}}
+        ally._mark_pending_device_sync("device-1", {"mode": "manual"})
+        ally._pending_device_syncs["device-1"].deadline = (
+            asyncio.get_running_loop().time() - 1
+        )
+
+        refresh_calls = 0
+
+        async def fake_refresh_device(device_id: str) -> dict[str, object]:
+            nonlocal refresh_calls
+            refresh_calls += 1
+            return {"id": device_id}
+
+        async def fake_get_devices() -> dict[str, dict[str, object]]:
+            return ally.devices
+
+        ally.get_devices = fake_get_devices  # type: ignore[method-assign]
+        ally.refresh_device = fake_refresh_device  # type: ignore[method-assign]
+
+        await ally.refresh_devices()
+
+        self.assertEqual(refresh_calls, 0)
+        self.assertEqual(ally._pending_device_syncs, {})
+
     def test_constructor_rejects_invalid_refresh_tuning(self) -> None:
         """Refresh tuning should reject invalid values early."""
         with self.assertRaises(ValueError):
@@ -244,6 +358,9 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(ValueError):
             DanfossAlly(refresh_device_min_interval=-0.1)
+
+        with self.assertRaises(ValueError):
+            DanfossAlly(refresh_device_timeout=-1)
 
     async def test_send_command_accepts_result_shape(self) -> None:
         """Command responses with a result field should be accepted."""


### PR DESCRIPTION
## Summary
- use `get_devices()` as the default refresh path again
- keep only locally written devices on the realtime `get_device()` path until bulk data catches up or times out

## Changes
- add pending per-device sync tracking keyed by the fields written through the client
- make `refresh_devices()` refresh the bulk snapshot first and only hot-refresh pending devices
- reduce pending-device refresh concurrency to 2 and add a 10 minute timeout
- clear pending device syncs when the bulk snapshot `t` value advances and reflects the expected fields
- update tests, examples, and README to cover the new refresh model

## Testing
- `PYTHONPATH=. pytest -q`

## Notes
- only fields written by this client are tracked for bulk-sync completion
- a new write to the same device extends and replaces the pending expectations for that device
