### PR TITLE
Improve debug logging across refresh flows

### DIFF
--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -215,6 +215,7 @@ class DanfossAlly:
 
     async def initialize(self, key: str, secret: str) -> bool:
         """Authorize and initialize the connection."""
+        _LOGGER.debug("Initializing DanfossAlly client")
         token = await self._api.get_token(key, secret)
 
         if token is False:
@@ -224,10 +225,12 @@ class DanfossAlly:
 
         self._token = self._api.token
         self._authorized = True
+        _LOGGER.debug("DanfossAlly client initialized successfully")
         return True
 
     async def get_devices(self) -> dict[str, dict[str, Any]]:
         """Fetch and parse all devices."""
+        _LOGGER.debug("Fetching bulk device snapshot")
         response = await self._api.get_devices()
         if not response or "result" not in response:
             _LOGGER.error("Something went wrong loading devices")
@@ -240,6 +243,11 @@ class DanfossAlly:
         for device in response["result"]:
             self._store_device(device, last_response_time=response.get("t"))
 
+        _LOGGER.debug(
+            "Loaded %s devices from bulk snapshot with t=%s",
+            len(self.devices),
+            current_bulk_response_time,
+        )
         self._last_bulk_response_time = current_bulk_response_time
         if (
             current_bulk_response_time is None
@@ -251,6 +259,7 @@ class DanfossAlly:
 
     async def get_device(self, device_id: str) -> dict[str, Any] | None:
         """Fetch one device and parse it into the cached device map."""
+        _LOGGER.debug("Fetching realtime state for device %s", device_id)
         response = await self._api.get_device(device_id)
         if not response or "result" not in response:
             _LOGGER.error("Something went wrong loading device %s", device_id)
@@ -290,11 +299,21 @@ class DanfossAlly:
 
     async def refresh_devices(self) -> dict[str, dict[str, Any]]:
         """Refresh the bulk snapshot, then keep pending devices on the realtime path."""
+        _LOGGER.debug(
+            "Starting refresh cycle (pending_devices=%s)",
+            len(self._pending_device_syncs),
+        )
         await self.get_devices()
 
         device_ids = self._active_pending_device_ids()
         if not device_ids:
+            _LOGGER.debug("Refresh cycle completed using bulk snapshot only")
             return self.devices
+
+        _LOGGER.debug(
+            "Refreshing %s pending device(s) via realtime endpoint",
+            len(device_ids),
+        )
 
         semaphore = asyncio.Semaphore(self._refresh_device_concurrency)
 
@@ -305,6 +324,7 @@ class DanfossAlly:
 
         await asyncio.gather(*(refresh_one(device_id) for device_id in device_ids))
 
+        _LOGGER.debug("Refresh cycle completed with pending realtime refreshes")
         return self.devices
 
     async def set_temperature(
@@ -367,6 +387,7 @@ class DanfossAlly:
 
     async def set_mode(self, device_id: str, mode: str) -> bool:
         """Update operating mode for one device."""
+        _LOGGER.debug("Setting mode for device %s to %s", device_id, mode)
         result = await self._api.set_mode(device_id, mode)
         if result:
             self._mark_pending_device_sync(device_id, {"mode": mode})
@@ -378,6 +399,11 @@ class DanfossAlly:
         listofcommands: list[tuple[str, Any]],
     ) -> bool:
         """Send generic commands for one device."""
+        _LOGGER.debug(
+            "Sending generic command(s) for device %s with codes=%s",
+            device_id,
+            [code for code, _ in listofcommands],
+        )
         result = await self._api.send_command(device_id, listofcommands)
         if result:
             self._mark_pending_device_sync(
@@ -396,6 +422,7 @@ class DanfossAlly:
         parsed = parse_device_data(device, last_response_time=last_response_time)
         device_id = device["id"]
         self.devices[device_id] = parsed
+        _LOGGER.debug("Stored parsed state for device %s", device_id)
         return parsed
 
     def _get_setpoint_code_for_mode(self, device: dict[str, Any], mode: str) -> str:
@@ -415,6 +442,10 @@ class DanfossAlly:
         ]
         for device_id in expired_device_ids:
             self._pending_device_syncs.pop(device_id, None)
+            _LOGGER.debug(
+                "Stopped realtime refresh for device %s because pending sync timed out",
+                device_id,
+            )
         return list(self._pending_device_syncs)
 
     def _clear_pending_device_syncs_from_bulk_snapshot(self) -> None:
@@ -429,6 +460,10 @@ class DanfossAlly:
         ]
         for device_id in satisfied_device_ids:
             self._pending_device_syncs.pop(device_id, None)
+            _LOGGER.debug(
+                "Stopped realtime refresh for device %s because bulk snapshot caught up",
+                device_id,
+            )
 
     def _mark_pending_device_sync(
         self,
@@ -447,6 +482,12 @@ class DanfossAlly:
         self._pending_device_syncs[device_id] = _PendingDeviceSync(
             expected_fields=merged_fields,
             deadline=deadline,
+        )
+        _LOGGER.debug(
+            "Marked device %s for pending realtime refresh with fields=%s until deadline=%s",
+            device_id,
+            sorted(merged_fields),
+            deadline,
         )
 
     def _expected_fields_from_commands(

--- a/pydanfossally/danfossallyapi.py
+++ b/pydanfossally/danfossallyapi.py
@@ -86,6 +86,11 @@ class DanfossAllyAPI:
     async def _async_get_client(self) -> httpx.AsyncClient:
         """Create the default async HTTP client on first use."""
         if self._client is None:
+            _LOGGER.debug(
+                "Creating async HTTP client for %s with timeout=%s",
+                API_HOST,
+                self._timeout,
+            )
             self._client = await asyncio.to_thread(
                 httpx.AsyncClient,
                 base_url=API_HOST,
@@ -102,6 +107,7 @@ class DanfossAllyAPI:
         if self._user_agent_suffix != _DEFAULT_USER_AGENT_SUFFIX:
             return
         self._user_agent_suffix = await asyncio.to_thread(_resolve_user_agent_suffix)
+        _LOGGER.debug("Resolved User-Agent suffix to %s", self._user_agent_suffix)
 
     @property
     def _user_agent(self) -> str:
@@ -148,6 +154,13 @@ class DanfossAllyAPI:
 
         request_headers = headers or self._auth_headers()
         client = await self._async_get_client()
+        _LOGGER.debug(
+            "Sending %s %s (payload=%s, auth_refresh=%s)",
+            method,
+            path,
+            "yes" if payload is not None else "no",
+            not skip_auth_refresh,
+        )
 
         try:
             response = await client.request(
@@ -157,45 +170,79 @@ class DanfossAllyAPI:
                 headers=request_headers,
             )
             response.raise_for_status()
+            _LOGGER.debug(
+                "Received %s response for %s %s",
+                response.status_code,
+                method,
+                path,
+            )
         except httpx.HTTPStatusError as err:
+            _LOGGER.debug(
+                "HTTP error for %s %s: status=%s",
+                method,
+                path,
+                err.response.status_code,
+            )
             raise self._map_http_error(err) from err
         except httpx.TimeoutException as err:
+            _LOGGER.debug("Timeout while calling %s %s", method, path)
             raise TimeoutError from err
         except httpx.ConnectError as err:
+            _LOGGER.debug("Connection error while calling %s %s", method, path)
             raise ConnectionError from err
         except httpx.HTTPError as err:
+            _LOGGER.debug("Unexpected HTTP error while calling %s %s: %s", method, path, err)
             raise UnexpectedError from err
 
         if not response.content:
+            _LOGGER.debug("Empty response body for %s %s", method, path)
             return {}
 
         try:
-            return response.json()
+            data = response.json()
+            _LOGGER.debug(
+                "Decoded JSON response for %s %s with keys=%s",
+                method,
+                path,
+                sorted(data.keys()),
+            )
+            return data
         except json.JSONDecodeError as err:
+            _LOGGER.debug("Failed to decode JSON response for %s %s", method, path)
             raise UnexpectedError from err
 
     def _map_http_error(self, err: httpx.HTTPStatusError) -> Exception:
         """Translate HTTP failures into domain-specific exceptions."""
         status_code = err.response.status_code
         if status_code == 400:
-            return BadRequestError()
-        if status_code == 401:
-            return UnauthorizedError()
-        if status_code == 403:
-            return ForbiddenError()
-        if status_code == 404:
-            return NotFoundError()
-        if status_code == 429:
-            return RateLimitError()
-        if 500 <= status_code <= 599:
-            return InternalServerError()
-        return APIError(f"Unexpected HTTP status code: {status_code}")
+            mapped = BadRequestError()
+        elif status_code == 401:
+            mapped = UnauthorizedError()
+        elif status_code == 403:
+            mapped = ForbiddenError()
+        elif status_code == 404:
+            mapped = NotFoundError()
+        elif status_code == 429:
+            mapped = RateLimitError()
+        elif 500 <= status_code <= 599:
+            mapped = InternalServerError()
+        else:
+            mapped = APIError(f"Unexpected HTTP status code: {status_code}")
+        _LOGGER.debug(
+            "Mapped HTTP status %s on %s to %s",
+            status_code,
+            err.request.url.path,
+            mapped.__class__.__name__,
+        )
+        return mapped
 
     async def _refresh_token(self) -> bool:
         """Refresh OAuth2 token when it has expired."""
         if self._refresh_at > datetime.datetime.now():
+            _LOGGER.debug("Skipping token refresh; cached token is still valid")
             return False
 
+        _LOGGER.debug("Refreshing OAuth token")
         return await self.get_token()
 
     async def get_token(
@@ -209,6 +256,7 @@ class DanfossAllyAPI:
             self._secret = secret
 
         if not self._key or not self._secret:
+            _LOGGER.debug("Token request skipped because credentials are missing")
             return False
 
         base64_token = self._generate_base64_token(self._key, self._secret)
@@ -223,6 +271,7 @@ class DanfossAllyAPI:
             )
             req.raise_for_status()
             response = req.json()
+            _LOGGER.debug("Token request succeeded with status %s", req.status_code)
         except httpx.HTTPStatusError as err:
             mapped_error = self._map_http_error(err)
             if isinstance(mapped_error, (BadRequestError, UnauthorizedError)):
@@ -249,6 +298,7 @@ class DanfossAllyAPI:
             seconds=expires_in - 30
         )
         self._token = response["access_token"]
+        _LOGGER.debug("Stored OAuth token with expires_in=%s seconds", expires_in)
         return True
 
     async def get_devices(self) -> dict[str, Any]:
@@ -284,7 +334,12 @@ class DanfossAllyAPI:
                 {"code": code, "value": value} for code, value in listofcommands
             ]
         }
-        _LOGGER.debug("Sending command to device %s: %s", device_id, request_body)
+        _LOGGER.debug(
+            "Sending %s command(s) to device %s with codes=%s",
+            len(listofcommands),
+            device_id,
+            [code for code, _ in listofcommands],
+        )
         response = await self._request(
             "POST",
             f"{ALLY_PREFIX}/devices/{device_id}/commands",


### PR DESCRIPTION
## Summary
- add more useful debug logging around requests, token handling, writes, and refresh decisions
- make it easier to understand why the client chooses bulk versus realtime refresh paths

## Changes
- add request/response debug logging around API calls and mapped HTTP errors
- log token refresh decisions, token request success, and missing-credential skips
- log bulk refresh cycles, pending realtime refreshes, and pending timeout/catch-up transitions
- log write operations and parsed device storage at key decision points

## Testing
- `PYTHONPATH=. pytest -q`

## Notes
- the new logging avoids secrets and full response payload dumps
- this is a first pass focused on the most useful places for troubleshooting live API issues
