### PR TITLE
Add periodic bulk device discovery refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ from pydanfossally import DanfossAlly
 ally = DanfossAlly(
     timeout=30,
     refresh_device_concurrency=5,
-    refresh_device_min_interval=0.35,
+    refresh_device_min_interval=0.10,
+    device_discovery_interval=3600,
     user_agent_prefix="HomeAssistant-DanfossAlly/2026.3.0",
 )
 
@@ -53,7 +54,8 @@ async def main() -> None:
     async with DanfossAlly(
         timeout=30,
         refresh_device_concurrency=5,
-        refresh_device_min_interval=0.35,
+        refresh_device_min_interval=0.10,
+        device_discovery_interval=3600,
         user_agent_prefix="HomeAssistant-DanfossAlly/2026.3.0",
     ) as ally:
         authorized = await ally.initialize(os.environ["KEY"], os.environ["SECRET"])
@@ -100,14 +102,16 @@ device-specific status or command codes. That means:
 ## Refresh behavior
 
 The library keeps `refresh_device()` on the near-realtime `GET /ally/devices/{device_id}`
-endpoint. Bulk `refresh_devices()` calls intentionally pace those per-device reads and use a
-small concurrency limit to reduce burst load against the upstream API.
+endpoint. Bulk discovery through `GET /ally/devices` is used when the cache is empty and then
+again on a slower periodic interval so newly added devices can be discovered.
 
 Both knobs are configurable through `DanfossAlly(...)`:
 
 - `refresh_device_concurrency` controls how many per-device refreshes may run at once
 - `refresh_device_min_interval` controls the minimum delay in seconds between starting two
   per-device refreshes
+- `device_discovery_interval` controls how often the bulk `/ally/devices` endpoint is used to
+  discover newly added devices
 
 ## User-Agent
 

--- a/example.py
+++ b/example.py
@@ -13,7 +13,8 @@ async def main() -> None:
     """Run a simple read-only session against the Danfoss Ally API."""
     async with DanfossAlly(
         refresh_device_concurrency=5,
-        refresh_device_min_interval=0.35,
+        refresh_device_min_interval=0.10,
+        device_discovery_interval=3600,
     ) as ally:
         authorized = await ally.initialize(environ["KEY"], environ["SECRET"])
         if not authorized:

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -54,6 +54,7 @@ _MODE_TO_SETPOINT_CODE = {
 }
 _REFRESH_DEVICE_CONCURRENCY = 5
 _REFRESH_DEVICE_MIN_INTERVAL = 0.10
+_DEVICE_DISCOVERY_INTERVAL = 3600.0
 
 
 def _normalize_bool(value: Any) -> bool | None:
@@ -165,6 +166,7 @@ class DanfossAlly:
         timeout: float = DEFAULT_TIMEOUT,
         refresh_device_concurrency: int = _REFRESH_DEVICE_CONCURRENCY,
         refresh_device_min_interval: float = _REFRESH_DEVICE_MIN_INTERVAL,
+        device_discovery_interval: float = _DEVICE_DISCOVERY_INTERVAL,
         user_agent_prefix: str | None = None,
     ) -> None:
         """Initialize the connector."""
@@ -172,6 +174,8 @@ class DanfossAlly:
             raise ValueError("refresh_device_concurrency must be at least 1")
         if refresh_device_min_interval < 0:
             raise ValueError("refresh_device_min_interval must be non-negative")
+        if device_discovery_interval < 0:
+            raise ValueError("device_discovery_interval must be non-negative")
 
         self._authorized = False
         self._token: str | None = None
@@ -182,8 +186,10 @@ class DanfossAlly:
         )
         self._refresh_device_concurrency = refresh_device_concurrency
         self._refresh_device_min_interval = refresh_device_min_interval
+        self._device_discovery_interval = device_discovery_interval
         self._refresh_rate_lock = asyncio.Lock()
         self._next_refresh_slot = 0.0
+        self._next_device_discovery_at = 0.0
 
     async def __aenter__(self) -> DanfossAlly:
         """Allow async context manager usage."""
@@ -223,6 +229,8 @@ class DanfossAlly:
         self.devices = {}
         for device in response["result"]:
             self._store_device(device, last_response_time=response.get("t"))
+
+        self._schedule_next_device_discovery()
 
         _LOGGER.debug(
             "Loaded %s devices from bulk snapshot with t=%s",
@@ -273,13 +281,17 @@ class DanfossAlly:
 
     async def refresh_devices(self) -> dict[str, dict[str, Any]]:
         """Refresh cached devices via their dedicated endpoints."""
-        device_ids = list(self.devices)
-        if not device_ids:
+        if not self.devices:
             _LOGGER.debug(
                 "Refresh requested without cached devices; loading bulk snapshot for discovery",
             )
             return await self.get_devices()
 
+        if self._should_refresh_device_discovery():
+            _LOGGER.debug("Device discovery interval elapsed; refreshing bulk device snapshot")
+            await self.get_devices()
+
+        device_ids = list(self.devices)
         semaphore = asyncio.Semaphore(self._refresh_device_concurrency)
 
         async def refresh_one(device_id: str) -> None:
@@ -291,6 +303,16 @@ class DanfossAlly:
 
         _LOGGER.debug("Refreshed %s known device(s) via realtime endpoint", len(device_ids))
         return self.devices
+
+    def _should_refresh_device_discovery(self) -> bool:
+        """Return whether periodic bulk discovery should run before device refresh."""
+        return asyncio.get_running_loop().time() >= self._next_device_discovery_at
+
+    def _schedule_next_device_discovery(self) -> None:
+        """Schedule the next bulk device discovery pass."""
+        self._next_device_discovery_at = (
+            asyncio.get_running_loop().time() + self._device_discovery_interval
+        )
 
     async def set_temperature(
         self,

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -310,6 +310,80 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("device-1", devices)
 
+    async def test_refresh_devices_skips_bulk_discovery_before_interval(self) -> None:
+        """Known devices should use direct refresh until the discovery interval elapses."""
+        bulk_calls = 0
+        realtime_calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal bulk_calls, realtime_calls
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                bulk_calls += 1
+                return httpx.Response(200, json={"result": [DEVICE_PAYLOAD], "t": 1})
+            if request.url.path == "/ally/devices/device-1":
+                realtime_calls += 1
+                return httpx.Response(200, json={"result": DEVICE_PAYLOAD, "t": 2})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(
+            api=await self._make_api(handler),
+            refresh_device_min_interval=0,
+            device_discovery_interval=3600,
+        )
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        await ally.refresh_devices()
+
+        self.assertEqual(bulk_calls, 1)
+        self.assertEqual(realtime_calls, 1)
+
+    async def test_refresh_devices_renews_bulk_discovery_after_interval(self) -> None:
+        """Hourly discovery should pick up new devices before direct refresh."""
+        bulk_calls = 0
+        realtime_calls: list[str] = []
+        second_device = {
+            **DEVICE_PAYLOAD,
+            "id": "device-2",
+            "name": " Bedroom ",
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal bulk_calls
+            if request.url.path == "/oauth2/token":
+                return httpx.Response(200, json=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                bulk_calls += 1
+                if bulk_calls == 1:
+                    return httpx.Response(200, json={"result": [DEVICE_PAYLOAD], "t": 1})
+                return httpx.Response(
+                    200,
+                    json={"result": [DEVICE_PAYLOAD, second_device], "t": 2},
+                )
+            if request.url.path.startswith("/ally/devices/"):
+                device_id = request.url.path.rsplit("/", 1)[-1]
+                realtime_calls.append(device_id)
+                payload = DEVICE_PAYLOAD if device_id == "device-1" else second_device
+                return httpx.Response(200, json={"result": payload, "t": 3})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(
+            api=await self._make_api(handler),
+            refresh_device_min_interval=0,
+            device_discovery_interval=3600,
+        )
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+        ally._next_device_discovery_at = asyncio.get_running_loop().time() - 1
+
+        devices = await ally.refresh_devices()
+
+        self.assertEqual(bulk_calls, 2)
+        self.assertCountEqual(realtime_calls, ["device-1", "device-2"])
+        self.assertIn("device-2", devices)
+
     def test_constructor_rejects_invalid_refresh_tuning(self) -> None:
         """Refresh tuning should reject invalid values early."""
         with self.assertRaises(ValueError):
@@ -317,6 +391,9 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(ValueError):
             DanfossAlly(refresh_device_min_interval=-0.1)
+
+        with self.assertRaises(ValueError):
+            DanfossAlly(device_discovery_interval=-0.1)
 
     async def test_send_command_accepts_result_shape(self) -> None:
         """Command responses with a result field should be accepted."""


### PR DESCRIPTION
## Summary
- refresh the bulk device snapshot on a periodic interval before the normal per-device refresh cycle
- keep the direct per-device refresh flow for known devices while allowing newly added devices to be discovered later
- preserve the cached device map so integrations can add newly discovered devices without a restart

## Test Strategy
- exercised through the downstream integration branch that now listens for coordinator-driven device discovery
- validated locally in the `danfoss_ally` integration with `pytest -q tests/test_entity.py tests/test_sensor.py tests/test_switch.py tests/test_climate.py tests/test_coordinator.py`

## Known Limitations
- this branch is intended to be consumed together with the matching `danfoss_ally` integration changes for full end-to-end validation

## Configuration Changes
- no user-facing configuration changes