### PR TITLE
Add release notes guidance to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,12 @@
 *   Keep documentation up-to-date with current code
 *   Danfoss Ally API OpenSpec is located in `/docs/openapi-spec`
 *   Always push changes to repository, when making changes in a branch
+*   Before committing, the agent MUST run the agreed `ruff` commands for this repository, including `ruff format` and `ruff check`, and fix any reported issues
+
+## Release Notes
+
+*   Release notes should ALWAYS be in english
+*   Keep the existing release note structure unless explicitly asked to change it
+*   The `## Changes` section should be short, easy to read, and written as plain prose without bullets
+*   Prefer 2-3 short paragraphs under `## Changes` instead of one dense block of text
+*   Base the `## Changes` text only on the PRs already included in the release draft unless told otherwise


### PR DESCRIPTION
## Summary
Add release note guidance to `AGENTS.md` so future release drafts keep the agreed structure and tone.

## Changes
Document that release notes must stay in english, keep the existing structure, and use a short prose-based `## Changes` section built only from the PRs already included in the draft.

## Testing
- `ruff format --preview AGENTS.md`
- `ruff check AGENTS.md`

## Notes
- Proposed semver label verified with user: `patch`
