### PR TITLE
Use git tags for package versioning

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
@@ -43,6 +45,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
+          poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -2,6 +2,10 @@ name: Deploy to PyPI
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish, for example v1.0.3"
+        required: true
   release:
     types: [published]
 
@@ -15,16 +19,18 @@ jobs:
     env:
       POETRY_VIRTUALENVS_CREATE: "false"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
 
       - name: Install poetry
         run: |
           pipx install poetry
-          pipx inject poetry poetry-bumpversion
+          pipx inject poetry "poetry-dynamic-versioning[plugin]"
 
       - name: Build
         run: |
-          poetry version ${{ github.ref_name }}
           poetry build
 
       - name: Publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["poetry-core>=1.9.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.9.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [project]
 name = "pydanfossally"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Danfoss Ally API library"
 readme = "README.md"
 license = "MIT"
@@ -18,6 +18,13 @@ Repository = "https://github.com/mtrab/pydanfossally"
 
 [tool.poetry]
 packages = [{ include = "pydanfossally" }]
+version = "0.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "semver"
+strict = true


### PR DESCRIPTION
## Summary
Switch package versioning to git tags so release builds and PyPI publishing use the tagged version instead of a static value in `pyproject.toml`.

## Changes
Enable dynamic versioning in `pyproject.toml`, update the PyPI publish workflow to build from the selected git tag, and update the test workflow so Poetry has the required plugin and tag history available in CI.

## Testing
- `ruff check`
- `ruff format pyproject.toml .github/workflows/pythonpublish.yml .github/workflows/python-tests.yml` *(fails because `ruff format` does not parse YAML in this environment)*
- `poetry check` *(run in a temporary virtualenv)*
- `poetry build` *(run in a temporary virtualenv; verified dynamic version output from git metadata)*

## Notes
- Proposed semver label verified with user: `patch`
- The publish workflow now checks out the release tag directly so PyPI releases resolve to the exact tag version, for example `1.0.3`
