### PR TITLE
Calm Danfoss API traffic with global request pacing

### DIFF
--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -15,7 +15,10 @@ from .const import (
     REFRESH_DEVICE_MIN_INTERVAL,
     SETPOINT_CODES,
 )
-from .danfossallyapi import DEFAULT_TIMEOUT, DanfossAllyAPI
+from .danfossallyapi import (
+    DEFAULT_TIMEOUT,
+    DanfossAllyAPI,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/pydanfossally/danfossallyapi.py
+++ b/pydanfossally/danfossallyapi.py
@@ -27,6 +27,7 @@ API_HOST = "https://api.danfoss.com"
 TOKEN_PATH = "/oauth2/token"
 ALLY_PREFIX = "/ally"
 DEFAULT_TIMEOUT = 10.0
+DEFAULT_REQUEST_RATE_LIMIT = 3.0
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,6 +67,9 @@ class DanfossAllyAPI:
         self._refresh_at = datetime.datetime.min
         self._owns_client = client is None
         self._timeout = timeout
+        self._request_rate_limit: float | None = DEFAULT_REQUEST_RATE_LIMIT
+        self._request_rate_lock = asyncio.Lock()
+        self._next_request_slot = 0.0
         self._client = client
         self._user_agent_prefix = user_agent_prefix
         self._user_agent_suffix = _DEFAULT_USER_AGENT_SUFFIX
@@ -154,6 +158,7 @@ class DanfossAllyAPI:
 
         request_headers = headers or self._auth_headers()
         client = await self._async_get_client()
+        await self._wait_for_request_slot()
         _LOGGER.debug(
             "Sending %s %s (payload=%s, auth_refresh=%s)",
             method,
@@ -191,7 +196,9 @@ class DanfossAllyAPI:
             _LOGGER.debug("Connection error while calling %s %s", method, path)
             raise ConnectionError from err
         except httpx.HTTPError as err:
-            _LOGGER.debug("Unexpected HTTP error while calling %s %s: %s", method, path, err)
+            _LOGGER.debug(
+                "Unexpected HTTP error while calling %s %s: %s", method, path, err
+            )
             raise UnexpectedError from err
 
         if not response.content:
@@ -210,6 +217,23 @@ class DanfossAllyAPI:
         except json.JSONDecodeError as err:
             _LOGGER.debug("Failed to decode JSON response for %s %s", method, path)
             raise UnexpectedError from err
+
+    async def _wait_for_request_slot(self) -> None:
+        """Throttle outbound requests so the API does not receive bursts."""
+        if self._request_rate_limit is None:
+            return
+
+        loop = asyncio.get_running_loop()
+        min_interval = 1 / self._request_rate_limit
+
+        async with self._request_rate_lock:
+            now = loop.time()
+            scheduled_at = max(now, self._next_request_slot)
+            self._next_request_slot = scheduled_at + min_interval
+
+        delay = scheduled_at - loop.time()
+        if delay > 0:
+            await asyncio.sleep(delay)
 
     def _map_http_error(self, err: httpx.HTTPStatusError) -> Exception:
         """Translate HTTP failures into domain-specific exceptions."""
@@ -262,6 +286,7 @@ class DanfossAllyAPI:
         base64_token = self._generate_base64_token(self._key, self._secret)
         post_data = "grant_type=client_credentials"
         client = await self._async_get_client()
+        await self._wait_for_request_slot()
 
         try:
             req = await client.post(

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -136,7 +136,10 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             "HomeAssistant-DanfossAlly/2026.3.0 pydanfossally/1.2.3",
         )
 
-    async def _make_api(self, handler) -> DanfossAllyAPI:
+    async def _make_api(
+        self,
+        handler,
+    ) -> DanfossAllyAPI:
         client = httpx.AsyncClient(
             base_url=API_HOST,
             transport=httpx.MockTransport(handler),
@@ -357,7 +360,9 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             if request.url.path == "/ally/devices":
                 bulk_calls += 1
                 if bulk_calls == 1:
-                    return httpx.Response(200, json={"result": [DEVICE_PAYLOAD], "t": 1})
+                    return httpx.Response(
+                        200, json={"result": [DEVICE_PAYLOAD], "t": 1}
+                    )
                 return httpx.Response(
                     200,
                     json={"result": [DEVICE_PAYLOAD, second_device], "t": 2},
@@ -394,6 +399,22 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(ValueError):
             DanfossAlly(device_discovery_interval=-0.1)
+
+    async def test_global_rate_limit_paces_reads_and_writes(self) -> None:
+        """All outbound API calls should share the same global pacing."""
+        api = await self._make_api(lambda request: httpx.Response(200, json={"t": 1}))
+        api._request_rate_limit = 50
+        started_at: list[float] = []
+
+        async def wait_for_slot() -> None:
+            await api._wait_for_request_slot()
+            started_at.append(asyncio.get_running_loop().time())
+
+        await asyncio.gather(wait_for_slot(), wait_for_slot(), wait_for_slot())
+
+        self.assertEqual(len(started_at), 3)
+        self.assertGreaterEqual(started_at[1] - started_at[0], 0.015)
+        self.assertGreaterEqual(started_at[2] - started_at[1], 0.015)
 
     async def test_send_command_accepts_result_shape(self) -> None:
         """Command responses with a result field should be accepted."""


### PR DESCRIPTION
## Summary
This change adds a global request limiter in `pydanfossally` so outbound Danfoss API calls are paced consistently across reads, writes, and token requests. The goal is to prevent bursty traffic from causing quota violations when integrations issue several operations close together.

## Test strategy
Validated locally with `pytest tests/test_async_client.py` and `ruff check pydanfossally/danfossallyapi.py pydanfossally/__init__.py tests/test_async_client.py`.

## Known limitations
This only controls how quickly the library sends requests. It does not change the integration-layer refresh policy on its own.

## Configuration changes
No user-facing configuration changes.
