### PR TITLE
Skip unchanged cached device writes

### DIFF
--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -480,8 +480,7 @@ class DanfossAlly:
         listofcommands: list[tuple[str, Any]],
     ) -> bool:
         """Send generic commands for one device."""
-        commands_to_send = self._filter_cached_noop_commands(device_id, listofcommands)
-        if not commands_to_send:
+        if self._should_skip_cached_command_call(device_id, listofcommands):
             _LOGGER.debug(
                 "Skipping command(s) for device %s because cached state already matches",
                 device_id,
@@ -491,9 +490,9 @@ class DanfossAlly:
         _LOGGER.debug(
             "Sending generic command(s) for device %s with codes=%s",
             device_id,
-            [code for code, _ in commands_to_send],
+            [code for code, _ in listofcommands],
         )
-        return await self._api.send_command(device_id, commands_to_send)
+        return await self._api.send_command(device_id, listofcommands)
 
     def _store_device(
         self,
@@ -526,27 +525,26 @@ class DanfossAlly:
             if self._is_high_priority_device(device_id)
         ]
 
-    def _filter_cached_noop_commands(
+    def _should_skip_cached_command_call(
         self,
         device_id: str,
         commands: list[tuple[str, Any]],
-    ) -> list[tuple[str, Any]]:
-        """Drop commands whose desired state already matches the cached device."""
+    ) -> bool:
+        """Return whether all commands already match the cached device state."""
         device = self.devices.get(device_id)
         if not device:
-            return commands
-        filtered_commands: list[tuple[str, Any]] = []
+            return False
         for code, value in commands:
-            if self._cached_command_matches(device, code, value):
-                _LOGGER.debug(
-                    "Skipping command %s for device %s because cached value already matches %s",
-                    code,
-                    device_id,
-                    value,
-                )
-                continue
-            filtered_commands.append((code, value))
-        return filtered_commands
+            if not self._cached_command_matches(device, code, value):
+                return False
+        for code, value in commands:
+            _LOGGER.debug(
+                "Skipping command %s for device %s because cached value already matches %s",
+                code,
+                device_id,
+                value,
+            )
+        return True
 
     def _cached_command_matches(
         self,

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -142,6 +142,15 @@ def _normalize_device_type(value: Any) -> str:
     return " ".join(normalized.split())
 
 
+def _values_match(current: Any, expected: Any) -> bool:
+    """Compare cached and desired values with light numeric tolerance."""
+    if isinstance(current, bool) or isinstance(expected, bool):
+        return current is expected
+    if isinstance(current, (int, float)) and isinstance(expected, (int, float)):
+        return abs(float(current) - float(expected)) < 0.001
+    return current == expected
+
+
 class DanfossAlly:
     """Async-first Danfoss Ally API connector."""
 
@@ -454,6 +463,14 @@ class DanfossAlly:
 
     async def set_mode(self, device_id: str, mode: str) -> bool:
         """Update operating mode for one device."""
+        device = self.devices.get(device_id)
+        if device and self._cached_command_matches(device, "mode", mode):
+            _LOGGER.debug(
+                "Skipping mode update for device %s because cached mode already matches %s",
+                device_id,
+                mode,
+            )
+            return True
         _LOGGER.debug("Setting mode for device %s to %s", device_id, mode)
         return await self._api.set_mode(device_id, mode)
 
@@ -463,12 +480,20 @@ class DanfossAlly:
         listofcommands: list[tuple[str, Any]],
     ) -> bool:
         """Send generic commands for one device."""
+        commands_to_send = self._filter_cached_noop_commands(device_id, listofcommands)
+        if not commands_to_send:
+            _LOGGER.debug(
+                "Skipping command(s) for device %s because cached state already matches",
+                device_id,
+            )
+            return True
+
         _LOGGER.debug(
             "Sending generic command(s) for device %s with codes=%s",
             device_id,
-            [code for code, _ in listofcommands],
+            [code for code, _ in commands_to_send],
         )
-        return await self._api.send_command(device_id, listofcommands)
+        return await self._api.send_command(device_id, commands_to_send)
 
     def _store_device(
         self,
@@ -500,6 +525,54 @@ class DanfossAlly:
             for device_id in self.devices
             if self._is_high_priority_device(device_id)
         ]
+
+    def _filter_cached_noop_commands(
+        self,
+        device_id: str,
+        commands: list[tuple[str, Any]],
+    ) -> list[tuple[str, Any]]:
+        """Drop commands whose desired state already matches the cached device."""
+        device = self.devices.get(device_id)
+        if not device:
+            return commands
+        filtered_commands: list[tuple[str, Any]] = []
+        for code, value in commands:
+            if self._cached_command_matches(device, code, value):
+                _LOGGER.debug(
+                    "Skipping command %s for device %s because cached value already matches %s",
+                    code,
+                    device_id,
+                    value,
+                )
+                continue
+            filtered_commands.append((code, value))
+        return filtered_commands
+
+    def _cached_command_matches(
+        self,
+        device: dict[str, Any],
+        code: str,
+        value: Any,
+    ) -> bool:
+        """Return whether a command already matches the cached parsed state."""
+        expected_key = code.lower()
+        expected_value = value
+
+        if code in SETPOINT_CODES:
+            expected_value = float(value) / 10
+        elif code in BOOLEAN_CODES:
+            expected_value = _normalize_bool(value)
+        elif code == "ext_measured_rs":
+            expected_value = float(value) / 100
+        elif code == "sensor_avg_temp":
+            expected_key = "external_sensor_temperature"
+            expected_value = float(value) / 10
+        elif code != "mode":
+            return False
+
+        if expected_value is None or expected_key not in device:
+            return False
+        return _values_match(device[expected_key], expected_value)
 
     def _is_high_priority_device(self, device_id: str) -> bool:
         """Classify devices that deserve near-realtime refreshes."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -797,6 +797,85 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(await ally.set_temperature("device-1", 22.0, code="temp_set"))
 
+    async def test_set_temperature_skips_write_when_cached_value_matches(self) -> None:
+        """Identical cached setpoints should not trigger a redundant API write."""
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(
+                    200,
+                    json_data={"result": [THERMOSTAT_WITH_MODE_SETPOINTS], "t": 1},
+                )
+            if request.url.path == "/ally/devices/device-1/commands":
+                raise AssertionError(
+                    "No command request expected for unchanged setpoint"
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        self.assertTrue(
+            await ally.set_temperature("device-1", 21.5, code="manual_mode_fast")
+        )
+
+    async def test_set_temperature_for_mode_skips_mode_and_setpoint_when_unchanged(
+        self,
+    ) -> None:
+        """Mode-aware writes should short-circuit when cached mode and setpoint match."""
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(
+                    200,
+                    json_data={"result": [THERMOSTAT_WITH_MODE_SETPOINTS], "t": 1},
+                )
+            if request.url.path == "/ally/devices/device-1/commands":
+                raise AssertionError(
+                    "No command request expected for unchanged mode write"
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        self.assertTrue(await ally.set_temperature_for_mode("device-1", 21.5, "manual"))
+
+    async def test_set_temperature_for_mode_only_sends_changed_portion(self) -> None:
+        """Mode-aware writes should skip unchanged mode commands and keep changed setpoints."""
+        command_payloads: list[dict[str, object]] = []
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(
+                    200,
+                    json_data={"result": [THERMOSTAT_WITH_MODE_SETPOINTS], "t": 1},
+                )
+            if request.url.path == "/ally/devices/device-1/commands":
+                payload = json.loads(request.content.decode())
+                command_payloads.append(payload)
+                self.assertEqual(
+                    payload,
+                    {"commands": [{"code": "manual_mode_fast", "value": 230}]},
+                )
+                return MockResponse(201, json_data={"result": True, "t": 7})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        self.assertTrue(await ally.set_temperature_for_mode("device-1", 23.0, "manual"))
+        self.assertEqual(len(command_payloads), 1)
+
     async def test_set_temperature_for_mode_sets_mode_before_mode_setpoint(
         self,
     ) -> None:
@@ -878,6 +957,36 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         ally = DanfossAlly(api=await self._make_api(handler))
         await ally.initialize("key", "secret")
+
+        self.assertTrue(await ally.set_external_temperature("device-1", 25.0))
+
+    async def test_set_external_temperature_skips_write_when_cached_state_matches(
+        self,
+    ) -> None:
+        """External temperature writes should be skipped when cached values already match."""
+        cached_device = {
+            **DEVICE_PAYLOAD,
+            "status": [
+                {"code": "radiator_covered", "value": True},
+                {"code": "ext_measured_rs", "value": 2500},
+                {"code": "sensor_avg_temp", "value": 250},
+            ],
+        }
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(200, json_data={"result": [cached_device], "t": 1})
+            if request.url.path == "/ally/devices/device-1/commands":
+                raise AssertionError(
+                    "No command request expected for unchanged external temperature"
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
 
         self.assertTrue(await ally.set_external_temperature("device-1", 25.0))
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -848,7 +848,7 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(await ally.set_temperature_for_mode("device-1", 21.5, "manual"))
 
     async def test_set_temperature_for_mode_only_sends_changed_portion(self) -> None:
-        """Mode-aware writes should skip unchanged mode commands and keep changed setpoints."""
+        """Mode-aware writes may skip the separate mode call and still send setpoint changes."""
         command_payloads: list[dict[str, object]] = []
 
         def handler(request: MockRequest) -> MockResponse:
@@ -982,6 +982,45 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
                 raise AssertionError(
                     "No command request expected for unchanged external temperature"
                 )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        self.assertTrue(await ally.set_external_temperature("device-1", 25.0))
+
+    async def test_set_external_temperature_sends_full_payload_when_any_value_changes(
+        self,
+    ) -> None:
+        """Multi-property writes should send the full command list when any value differs."""
+        cached_device = {
+            **DEVICE_PAYLOAD,
+            "status": [
+                {"code": "radiator_covered", "value": True},
+                {"code": "ext_measured_rs", "value": 2400},
+                {"code": "sensor_avg_temp", "value": 240},
+            ],
+        }
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(200, json_data={"result": [cached_device], "t": 1})
+            if request.url.path == "/ally/devices/device-1/commands":
+                payload = json.loads(request.content.decode())
+                self.assertEqual(
+                    payload,
+                    {
+                        "commands": [
+                            {"code": "radiator_covered", "value": True},
+                            {"code": "ext_measured_rs", "value": 2500},
+                            {"code": "sensor_avg_temp", "value": 250},
+                        ]
+                    },
+                )
+                return MockResponse(201, json_data={"result": True, "t": 14})
             raise AssertionError(f"Unexpected request: {request.method} {request.url}")
 
         ally = DanfossAlly(api=await self._make_api(handler))


### PR DESCRIPTION
## Summary
Avoid redundant Danfoss Ally API writes when the cached device state already matches the requested value.

## Changes
The client now checks the cached parsed device state before sending writes for known writable properties. A write call is skipped only when every property in that command payload already matches the cached state, and the skip happens silently with debug logging.

This keeps multi-property writes atomic from the client's perspective: if any property in the payload differs, the full original command payload is still sent to the API. Tests were added for identical setpoint writes, identical mode-aware writes, unchanged external temperature writes, and mixed multi-property payloads where only some values match.

## Testing
- `poetry run ruff format pydanfossally tests example.py`
- `poetry run ruff check pydanfossally tests`
- `poetry run pytest tests/test_async_client.py`

## Notes
- Base branch: `master`
- Release/semver label not set yet pending explicit confirmation
