### PR TITLE
Add rolling diagnostic counters

### DIFF
--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -762,7 +762,7 @@ class DanfossAlly:
         )
         _LOGGER.debug(
             "  unsupported_status_devices=%s",
-            ", ".join(diagnostics["unsupported_status_devices"]),
+            ", ".join(diagnostics["unsupported_status_devices"]) or "none",
         )
         _LOGGER.debug(
             "  skipped_write_calls=%s",

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict, deque
 import logging
 import re
+import time
 from typing import Any
 
 from .const import (
@@ -20,6 +22,7 @@ from .const import (
 )
 from .danfossallyapi import (
     DEFAULT_TIMEOUT,
+    DIAGNOSTIC_WINDOW_SECONDS,
     DanfossAllyAPI,
 )
 from .exceptions import InternalServerError, RateLimitError
@@ -186,12 +189,16 @@ class DanfossAlly:
         self._refresh_device_min_interval = refresh_device_min_interval
         self._device_discovery_interval = device_discovery_interval
         self._degraded_refresh_cooldown = degraded_refresh_cooldown
+        self._diagnostic_window = DIAGNOSTIC_WINDOW_SECONDS
         self._refresh_rate_lock = asyncio.Lock()
         self._next_refresh_slot = 0.0
         self._next_device_discovery_at = 0.0
         self._degraded_refresh_until = 0.0
         self._status_refresh_recovery_limit: int | None = None
-        self._status_refresh_unsupported: set[str] = set()
+        self._status_refresh_unsupported: dict[str, float] = {}
+        self._skipped_refresh_times: dict[str, deque[float]] = defaultdict(deque)
+        self._degraded_mode_entry_times: deque[float] = deque()
+        self._skipped_write_times: deque[float] = deque()
 
     async def __aenter__(self) -> DanfossAlly:
         """Allow async context manager usage."""
@@ -240,6 +247,7 @@ class DanfossAlly:
             len(self.devices),
             response.get("t"),
         )
+        self._log_diagnostics("bulk device snapshot")
         return self.devices
 
     async def get_device(self, device_id: str) -> dict[str, Any] | None:
@@ -277,7 +285,8 @@ class DanfossAlly:
                 "Status refresh is unsupported for device %s; falling back to full device reads",
                 device_id,
             )
-            self._status_refresh_unsupported.add(device_id)
+            self._status_refresh_unsupported[device_id] = time.monotonic()
+            self._log_diagnostics("unsupported status refresh fallback")
             return await self.get_device(device_id)
 
     async def refresh_device_status(self, device_id: str) -> dict[str, Any] | None:
@@ -329,10 +338,12 @@ class DanfossAlly:
 
         device_ids = self._get_high_priority_refresh_candidates()
         if not device_ids:
+            self._record_skipped_refresh("no_high_priority_candidates")
             _LOGGER.debug("No high-priority devices eligible for per-device refresh")
             return self.devices
 
         if self._is_degraded_refresh_active():
+            self._record_skipped_refresh("degraded_mode", len(device_ids))
             _LOGGER.debug(
                 "Per-device refreshes are in cooldown until %.3f; returning bulk-backed cache only",
                 self._degraded_refresh_until,
@@ -350,6 +361,7 @@ class DanfossAlly:
             nonlocal rate_limited
             async with semaphore:
                 if rate_limited:
+                    self._record_skipped_refresh("rate_limited_remainder")
                     return
                 await self._wait_for_refresh_slot()
                 try:
@@ -465,6 +477,7 @@ class DanfossAlly:
         """Update operating mode for one device."""
         device = self.devices.get(device_id)
         if device and self._cached_command_matches(device, "mode", mode):
+            self._record_timestamp(self._skipped_write_times)
             _LOGGER.debug(
                 "Skipping mode update for device %s because cached mode already matches %s",
                 device_id,
@@ -481,6 +494,7 @@ class DanfossAlly:
     ) -> bool:
         """Send generic commands for one device."""
         if self._should_skip_cached_command_call(device_id, listofcommands):
+            self._record_timestamp(self._skipped_write_times)
             _LOGGER.debug(
                 "Skipping command(s) for device %s because cached state already matches",
                 device_id,
@@ -572,6 +586,23 @@ class DanfossAlly:
             return False
         return _values_match(device[expected_key], expected_value)
 
+    def _record_skipped_refresh(self, reason: str, count: int = 1) -> None:
+        """Count refreshes that were skipped by policy or cooldown."""
+        timestamps = self._skipped_refresh_times[reason]
+        for _ in range(count):
+            self._record_timestamp(timestamps)
+
+    def _record_timestamp(self, timestamps: deque[float]) -> None:
+        """Record one diagnostics event in the rolling window."""
+        timestamps.append(time.monotonic())
+        self._prune_timestamps(timestamps)
+
+    def _prune_timestamps(self, timestamps: deque[float]) -> None:
+        """Drop diagnostics entries that fall outside the rolling window."""
+        cutoff = time.monotonic() - self._diagnostic_window
+        while timestamps and timestamps[0] < cutoff:
+            timestamps.popleft()
+
     def _is_high_priority_device(self, device_id: str) -> bool:
         """Classify devices that deserve near-realtime refreshes."""
         parsed = self.devices.get(device_id, {})
@@ -618,10 +649,12 @@ class DanfossAlly:
             max(now, self._degraded_refresh_until) + self._degraded_refresh_cooldown
         )
         self._status_refresh_recovery_limit = 1
+        self._record_timestamp(self._degraded_mode_entry_times)
         _LOGGER.debug(
             "Entering degraded refresh mode until %.3f after rate limiting",
             self._degraded_refresh_until,
         )
+        self._log_diagnostics("degraded refresh entry")
 
     def _advance_status_refresh_recovery(self, total_candidates: int) -> None:
         """Gradually restore per-device refresh breadth after cooldown."""
@@ -653,3 +686,58 @@ class DanfossAlly:
     def token(self) -> str | None:
         """Return the cached bearer token."""
         return self._token
+
+    def get_diagnostics(self) -> dict[str, Any]:
+        """Return lightweight diagnostics for refresh tuning and debugging."""
+        skipped_refreshes: dict[str, int] = {}
+        for reason, timestamps in self._skipped_refresh_times.items():
+            self._prune_timestamps(timestamps)
+            if timestamps:
+                skipped_refreshes[reason] = len(timestamps)
+
+        self._prune_timestamps(self._degraded_mode_entry_times)
+        self._prune_timestamps(self._skipped_write_times)
+
+        cutoff = time.monotonic() - self._diagnostic_window
+        unsupported_status_devices = sorted(
+            device_id
+            for device_id, seen_at in self._status_refresh_unsupported.items()
+            if seen_at >= cutoff
+        )
+        return {
+            "request_counts": self._api.get_diagnostics()["request_counts"],
+            "skipped_refreshes": dict(sorted(skipped_refreshes.items())),
+            "degraded_mode_entries": len(self._degraded_mode_entry_times),
+            "unsupported_status_devices": unsupported_status_devices,
+            "unsupported_status_device_count": len(unsupported_status_devices),
+            "skipped_write_calls": len(self._skipped_write_times),
+        }
+
+    def _log_diagnostics(self, context: str) -> None:
+        """Emit a compact diagnostics snapshot in debug logs."""
+        diagnostics = self.get_diagnostics()
+        _LOGGER.debug(
+            "Diagnostics after %s (last %sm)",
+            context,
+            int(self._diagnostic_window // 60),
+        )
+        for endpoint, count in diagnostics["request_counts"].items():
+            _LOGGER.debug("  requests.%s=%s", endpoint, count)
+        for reason, count in diagnostics["skipped_refreshes"].items():
+            _LOGGER.debug("  skipped_refreshes.%s=%s", reason, count)
+        _LOGGER.debug(
+            "  degraded_mode_entries=%s",
+            diagnostics["degraded_mode_entries"],
+        )
+        _LOGGER.debug(
+            "  unsupported_status_device_count=%s",
+            diagnostics["unsupported_status_device_count"],
+        )
+        _LOGGER.debug(
+            "  unsupported_status_devices=%s",
+            ", ".join(diagnostics["unsupported_status_devices"]),
+        )
+        _LOGGER.debug(
+            "  skipped_write_calls=%s",
+            diagnostics["skipped_write_calls"],
+        )

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -235,10 +235,37 @@ class DanfossAlly:
             _LOGGER.error("Something went wrong loading devices")
             return self.devices
 
+        bulk_response_time = response.get("t")
+        previous_devices = self.devices
+        previous_metadata = self._device_metadata
         self.devices = {}
         self._device_metadata = {}
         for device in response["result"]:
-            self._store_device(device, last_response_time=response.get("t"))
+            device_id = device["id"]
+            cached_device = previous_devices.get(device_id)
+            cached_metadata = previous_metadata.get(device_id)
+            cached_response_time = (
+                cached_device.get("last_response_time") if cached_device else None
+            )
+
+            if (
+                bulk_response_time is not None
+                and isinstance(cached_response_time, (int, float))
+                and cached_response_time > bulk_response_time
+                and cached_metadata is not None
+            ):
+                self.devices[device_id] = cached_device.copy()
+                self._device_metadata[device_id] = dict(cached_metadata)
+                _LOGGER.debug(
+                    "Keeping cached device %s because cached t=%s is newer than bulk t=%s",
+                    device_id,
+                    cached_response_time,
+                    bulk_response_time,
+                )
+                self._record_skipped_refresh("stale_bulk_device")
+                continue
+
+            self._store_device(device, last_response_time=bulk_response_time)
 
         self._schedule_next_device_discovery()
 

--- a/pydanfossally/danfossallyapi.py
+++ b/pydanfossally/danfossallyapi.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from collections import defaultdict, deque
 import datetime
 from importlib import metadata
 import json
 import logging
+import re
+import time
 from typing import Any
 
 import aiohttp
@@ -28,6 +31,7 @@ TOKEN_PATH = "/oauth2/token"
 ALLY_PREFIX = "/ally"
 DEFAULT_TIMEOUT = 10.0
 DEFAULT_REQUEST_RATE_LIMIT = 3.0
+DIAGNOSTIC_WINDOW_SECONDS = 3600.0
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,6 +44,7 @@ _MODE_TO_LAST_CLICK_TIME_FORMAT_MAP = {
 
 _PACKAGE_NAME = "pydanfossally"
 _DEFAULT_USER_AGENT_SUFFIX = f"{_PACKAGE_NAME}/unknown"
+_DEVICE_PATH_PATTERN = re.compile(r"^/ally/devices/[^/]+")
 
 
 def _resolve_user_agent_suffix() -> str:
@@ -49,6 +54,15 @@ def _resolve_user_agent_suffix() -> str:
     except metadata.PackageNotFoundError:
         version = "unknown"
     return f"{_PACKAGE_NAME}/{version}"
+
+
+def _normalize_endpoint_path(path: str) -> str:
+    """Normalize dynamic device paths into stable endpoint names."""
+    if path == TOKEN_PATH:
+        return path
+    if path.startswith(f"{ALLY_PREFIX}/devices/"):
+        return _DEVICE_PATH_PATTERN.sub(f"{ALLY_PREFIX}/devices/{{device_id}}", path)
+    return path
 
 
 class DanfossAllyAPI:
@@ -73,6 +87,8 @@ class DanfossAllyAPI:
         self._client = client
         self._user_agent_prefix = user_agent_prefix
         self._user_agent_suffix = _DEFAULT_USER_AGENT_SUFFIX
+        self._diagnostic_window = DIAGNOSTIC_WINDOW_SECONDS
+        self._endpoint_request_times: dict[str, deque[float]] = defaultdict(deque)
 
     async def __aenter__(self) -> DanfossAllyAPI:
         """Allow async context manager usage."""
@@ -158,6 +174,7 @@ class DanfossAllyAPI:
         request_headers = headers or self._auth_headers()
         client = await self._async_get_client()
         await self._wait_for_request_slot()
+        self._record_request(path)
         _LOGGER.debug(
             "Sending %s %s (payload=%s, auth_refresh=%s)",
             method,
@@ -261,6 +278,19 @@ class DanfossAllyAPI:
         )
         return mapped
 
+    def _record_request(self, path: str) -> None:
+        """Count requests by normalized endpoint path."""
+        endpoint = _normalize_endpoint_path(path)
+        timestamps = self._endpoint_request_times[endpoint]
+        timestamps.append(time.monotonic())
+        self._prune_timestamps(timestamps)
+
+    def _prune_timestamps(self, timestamps: deque[float]) -> None:
+        """Drop diagnostics entries that fall outside the rolling window."""
+        cutoff = time.monotonic() - self._diagnostic_window
+        while timestamps and timestamps[0] < cutoff:
+            timestamps.popleft()
+
     async def _refresh_token(self) -> bool:
         """Refresh OAuth2 token when it has expired."""
         if self._refresh_at > datetime.datetime.now():
@@ -288,6 +318,7 @@ class DanfossAllyAPI:
         post_data = "grant_type=client_credentials"
         client = await self._async_get_client()
         await self._wait_for_request_slot()
+        self._record_request(TOKEN_PATH)
 
         try:
             async with client.post(
@@ -412,3 +443,14 @@ class DanfossAllyAPI:
     def token(self) -> str:
         """Return the cached OAuth token."""
         return self._token
+
+    def get_diagnostics(self) -> dict[str, dict[str, int]]:
+        """Return lightweight API diagnostics for debugging and tuning."""
+        request_counts: dict[str, int] = {}
+        for endpoint, timestamps in self._endpoint_request_times.items():
+            self._prune_timestamps(timestamps)
+            if timestamps:
+                request_counts[endpoint] = len(timestamps)
+        return {
+            "request_counts": dict(sorted(request_counts.items())),
+        }

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -346,6 +346,65 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(status[0]["code"], "temp_set")
         self.assertEqual(sub_devices[0]["id"], "child-1")
 
+    async def test_api_diagnostics_count_requests_per_normalized_endpoint(self) -> None:
+        """API diagnostics should count requests by stable endpoint names."""
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(200, json_data={"result": [DEVICE_PAYLOAD], "t": 1})
+            if request.url.path == "/ally/devices/device-1/status":
+                return MockResponse(
+                    200,
+                    json_data={"result": [{"code": "temp_set", "value": 215}], "t": 2},
+                )
+            if request.url.path == "/ally/devices/device-1/commands":
+                return MockResponse(201, json_data={"result": True, "t": 3})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+        await ally.get_device_status("device-1")
+        await ally.send_command("device-1", [("temp_set", 220)])
+
+        diagnostics = ally.get_diagnostics()
+
+        self.assertEqual(diagnostics["request_counts"]["/oauth2/token"], 1)
+        self.assertEqual(diagnostics["request_counts"]["/ally/devices"], 1)
+        self.assertEqual(
+            diagnostics["request_counts"]["/ally/devices/{device_id}/status"], 1
+        )
+        self.assertEqual(
+            diagnostics["request_counts"]["/ally/devices/{device_id}/commands"], 1
+        )
+
+    async def test_bulk_diagnostics_log_one_key_per_line(self) -> None:
+        """Bulk diagnostics should log a readable one-key-per-line summary."""
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(200, json_data={"result": [DEVICE_PAYLOAD], "t": 1})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        with self.assertLogs("pydanfossally", level="DEBUG") as captured_logs:
+            await ally.get_devices()
+
+        log_output = "\n".join(captured_logs.output)
+        self.assertIn(
+            "Diagnostics after bulk device snapshot (last 60m)",
+            log_output,
+        )
+        self.assertIn("requests./ally/devices=1", log_output)
+        self.assertIn("unsupported_status_device_count=0", log_output)
+        self.assertIn("skipped_write_calls=0", log_output)
+
     async def test_refresh_device_uses_status_endpoint_when_supported(self) -> None:
         """High-priority devices should prefer the status endpoint."""
         status_calls = 0
@@ -742,6 +801,10 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         await ally.refresh_devices()
         self.assertCountEqual(refreshed_ids, ["device-1", "device-1", "device-2"])
 
+        diagnostics = ally.get_diagnostics()
+        self.assertEqual(diagnostics["degraded_mode_entries"], 1)
+        self.assertEqual(diagnostics["skipped_refreshes"]["degraded_mode"], 2)
+
     async def test_global_rate_limit_paces_reads_and_writes(self) -> None:
         """All outbound API calls should share the same global pacing."""
         api = await self._make_api(
@@ -1028,6 +1091,41 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         await ally.get_devices()
 
         self.assertTrue(await ally.set_external_temperature("device-1", 25.0))
+
+    async def test_diagnostics_track_skipped_write_calls_and_unsupported_status(
+        self,
+    ) -> None:
+        """Wrapper diagnostics should expose skipped writes and unsupported status devices."""
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(
+                    200, json_data={"result": [ROOM_SENSOR_PAYLOAD], "t": 1}
+                )
+            if request.url.path == "/ally/devices/sensor-1/status":
+                return MockResponse(500, json_data={"title": "Internal Server Error"})
+            if request.url.path == "/ally/devices/sensor-1":
+                return MockResponse(
+                    200,
+                    json_data={"result": ROOM_SENSOR_PAYLOAD, "t": 15},
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+        await ally.refresh_device("sensor-1")
+
+        ally._store_device(THERMOSTAT_WITH_MODE_SETPOINTS)  # type: ignore[attr-defined]
+        await ally.set_temperature("device-1", 21.5, code="manual_mode_fast")
+
+        diagnostics = ally.get_diagnostics()
+
+        self.assertEqual(diagnostics["skipped_write_calls"], 1)
+        self.assertEqual(diagnostics["unsupported_status_device_count"], 1)
+        self.assertEqual(diagnostics["unsupported_status_devices"], ["sensor-1"])
 
     async def test_set_radiator_covered_false_clears_external_temperature(self) -> None:
         """Disabling covered-radiator mode should clear external sensor values."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -319,6 +319,122 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         assert device is not None
         self.assertEqual(device["last_response_time"], 12)
 
+    async def test_get_devices_keeps_newer_realtime_cache_than_bulk(self) -> None:
+        """Bulk refresh should not overwrite a device with older than cached realtime data."""
+        bulk_calls = 0
+
+        def handler(request: MockRequest) -> MockResponse:
+            nonlocal bulk_calls
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                bulk_calls += 1
+                if bulk_calls == 1:
+                    return MockResponse(
+                        200, json_data={"result": [DEVICE_PAYLOAD], "t": 10}
+                    )
+                return MockResponse(
+                    200,
+                    json_data={
+                        "result": [
+                            {
+                                **DEVICE_PAYLOAD,
+                                "status": [
+                                    {"code": "temp_set", "value": 180},
+                                    {"code": "temp_current", "value": 181},
+                                ],
+                            }
+                        ],
+                        "t": 11,
+                    },
+                )
+            if request.url.path == "/ally/devices/device-1":
+                return MockResponse(
+                    200,
+                    json_data={
+                        "result": {
+                            **DEVICE_PAYLOAD,
+                            "status": [
+                                {"code": "temp_set", "value": 230},
+                                {"code": "temp_current", "value": 205},
+                            ],
+                        },
+                        "t": 20,
+                    },
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+        await ally.get_device("device-1")
+
+        devices = await ally.get_devices()
+
+        self.assertEqual(devices["device-1"]["temp_set"], 23.0)
+        self.assertEqual(devices["device-1"]["temperature"], 20.5)
+        self.assertEqual(devices["device-1"]["last_response_time"], 20)
+        self.assertEqual(
+            ally.get_diagnostics()["skipped_refreshes"]["stale_bulk_device"],
+            1,
+        )
+
+    async def test_get_devices_accepts_newer_bulk_than_cached_realtime(self) -> None:
+        """Bulk refresh should overwrite cached devices when the bulk timestamp is newer."""
+        bulk_calls = 0
+
+        def handler(request: MockRequest) -> MockResponse:
+            nonlocal bulk_calls
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                bulk_calls += 1
+                if bulk_calls == 1:
+                    return MockResponse(
+                        200, json_data={"result": [DEVICE_PAYLOAD], "t": 10}
+                    )
+                return MockResponse(
+                    200,
+                    json_data={
+                        "result": [
+                            {
+                                **DEVICE_PAYLOAD,
+                                "status": [
+                                    {"code": "temp_set", "value": 180},
+                                    {"code": "temp_current", "value": 181},
+                                ],
+                            }
+                        ],
+                        "t": 30,
+                    },
+                )
+            if request.url.path == "/ally/devices/device-1":
+                return MockResponse(
+                    200,
+                    json_data={
+                        "result": {
+                            **DEVICE_PAYLOAD,
+                            "status": [
+                                {"code": "temp_set", "value": 230},
+                                {"code": "temp_current", "value": 205},
+                            ],
+                        },
+                        "t": 20,
+                    },
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+        await ally.get_device("device-1")
+
+        devices = await ally.get_devices()
+
+        self.assertEqual(devices["device-1"]["temp_set"], 18.0)
+        self.assertEqual(devices["device-1"]["temperature"], 18.1)
+        self.assertEqual(devices["device-1"]["last_response_time"], 30)
+
     async def test_get_device_status_and_sub_devices(self) -> None:
         """Spec-defined read-only endpoints should be available."""
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -519,6 +519,7 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIn("requests./ally/devices=1", log_output)
         self.assertIn("unsupported_status_device_count=0", log_output)
+        self.assertIn("unsupported_status_devices=none", log_output)
         self.assertIn("skipped_write_calls=0", log_output)
 
     async def test_refresh_device_uses_status_endpoint_when_supported(self) -> None:


### PR DESCRIPTION
## Summary
Add rolling diagnostic counters and protect cached realtime data from being overwritten by stale bulk refreshes.

## Changes
The client now tracks lightweight diagnostics for the last 60 minutes, including normalized request counts per endpoint, skipped refreshes, degraded-mode entries, unsupported `/status` devices, and skipped write calls. These diagnostics are logged in a more human-readable one-key-per-line format when bulk snapshots are loaded and when notable refresh fallback events happen.

Bulk refresh handling was also tightened so cached device data is preserved when a bulk `/ally/devices` response carries an older `t` value than the device already has from a newer realtime refresh. That prevents the cache from regressing while still allowing bulk discovery of new devices.

Tests were added for normalized endpoint counters, readable diagnostics logging, rolling diagnostics snapshots, and stale bulk refresh protection.

## Testing
- `poetry run ruff format pydanfossally tests example.py`
- `poetry run ruff check pydanfossally tests`
- `poetry run pytest tests/test_async_client.py`

## Notes
- Base branch: `master`
- Release/semver label not set yet pending explicit confirmation
