### PR TITLE
Fix Poetry metadata for Home Assistant git installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ Homepage = "https://github.com/mtrab/pydanfossally"
 Repository = "https://github.com/mtrab/pydanfossally"
 
 [tool.poetry]
+name = "pydanfossally"
+description = "Danfoss Ally API library"
+authors = ["Malene Trab <malene@trab.dk>"]
 packages = [{ include = "pydanfossally" }]
 version = "0.0.0"
 


### PR DESCRIPTION
## Summary
Add the standard package metadata fields to `[tool.poetry]` so git-based installs build reliably in stricter Poetry package-mode environments such as Home Assistant OS.

## Test strategy
- `ruff check .`
- `ruff format --check .`
- `poetry install`
- `poetry build`
- `poetry run pytest -q`
- `poetry run python -m compileall pydanfossally tests example.py`

## Known limitations
This change only improves packaging compatibility. It does not change runtime behavior or API functionality.

## Configuration changes
None.
