### PR TITLE
Always send explicit device writes

### DIFF
--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -145,15 +145,6 @@ def _normalize_device_type(value: Any) -> str:
     return " ".join(normalized.split())
 
 
-def _values_match(current: Any, expected: Any) -> bool:
-    """Compare cached and desired values with light numeric tolerance."""
-    if isinstance(current, bool) or isinstance(expected, bool):
-        return current is expected
-    if isinstance(current, (int, float)) and isinstance(expected, (int, float)):
-        return abs(float(current) - float(expected)) < 0.001
-    return current == expected
-
-
 class DanfossAlly:
     """Async-first Danfoss Ally API connector."""
 
@@ -198,7 +189,6 @@ class DanfossAlly:
         self._status_refresh_unsupported: dict[str, float] = {}
         self._skipped_refresh_times: dict[str, deque[float]] = defaultdict(deque)
         self._degraded_mode_entry_times: deque[float] = deque()
-        self._skipped_write_times: deque[float] = deque()
 
     async def __aenter__(self) -> DanfossAlly:
         """Allow async context manager usage."""
@@ -502,15 +492,6 @@ class DanfossAlly:
 
     async def set_mode(self, device_id: str, mode: str) -> bool:
         """Update operating mode for one device."""
-        device = self.devices.get(device_id)
-        if device and self._cached_command_matches(device, "mode", mode):
-            self._record_timestamp(self._skipped_write_times)
-            _LOGGER.debug(
-                "Skipping mode update for device %s because cached mode already matches %s",
-                device_id,
-                mode,
-            )
-            return True
         _LOGGER.debug("Setting mode for device %s to %s", device_id, mode)
         return await self._api.set_mode(device_id, mode)
 
@@ -520,14 +501,6 @@ class DanfossAlly:
         listofcommands: list[tuple[str, Any]],
     ) -> bool:
         """Send generic commands for one device."""
-        if self._should_skip_cached_command_call(device_id, listofcommands):
-            self._record_timestamp(self._skipped_write_times)
-            _LOGGER.debug(
-                "Skipping command(s) for device %s because cached state already matches",
-                device_id,
-            )
-            return True
-
         _LOGGER.debug(
             "Sending generic command(s) for device %s with codes=%s",
             device_id,
@@ -565,53 +538,6 @@ class DanfossAlly:
             for device_id in self.devices
             if self._is_high_priority_device(device_id)
         ]
-
-    def _should_skip_cached_command_call(
-        self,
-        device_id: str,
-        commands: list[tuple[str, Any]],
-    ) -> bool:
-        """Return whether all commands already match the cached device state."""
-        device = self.devices.get(device_id)
-        if not device:
-            return False
-        for code, value in commands:
-            if not self._cached_command_matches(device, code, value):
-                return False
-        for code, value in commands:
-            _LOGGER.debug(
-                "Skipping command %s for device %s because cached value already matches %s",
-                code,
-                device_id,
-                value,
-            )
-        return True
-
-    def _cached_command_matches(
-        self,
-        device: dict[str, Any],
-        code: str,
-        value: Any,
-    ) -> bool:
-        """Return whether a command already matches the cached parsed state."""
-        expected_key = code.lower()
-        expected_value = value
-
-        if code in SETPOINT_CODES:
-            expected_value = float(value) / 10
-        elif code in BOOLEAN_CODES:
-            expected_value = _normalize_bool(value)
-        elif code == "ext_measured_rs":
-            expected_value = float(value) / 100
-        elif code == "sensor_avg_temp":
-            expected_key = "external_sensor_temperature"
-            expected_value = float(value) / 10
-        elif code != "mode":
-            return False
-
-        if expected_value is None or expected_key not in device:
-            return False
-        return _values_match(device[expected_key], expected_value)
 
     def _record_skipped_refresh(self, reason: str, count: int = 1) -> None:
         """Count refreshes that were skipped by policy or cooldown."""
@@ -723,7 +649,6 @@ class DanfossAlly:
                 skipped_refreshes[reason] = len(timestamps)
 
         self._prune_timestamps(self._degraded_mode_entry_times)
-        self._prune_timestamps(self._skipped_write_times)
 
         cutoff = time.monotonic() - self._diagnostic_window
         unsupported_status_devices = sorted(
@@ -737,7 +662,6 @@ class DanfossAlly:
             "degraded_mode_entries": len(self._degraded_mode_entry_times),
             "unsupported_status_devices": unsupported_status_devices,
             "unsupported_status_device_count": len(unsupported_status_devices),
-            "skipped_write_calls": len(self._skipped_write_times),
         }
 
     def _log_diagnostics(self, context: str) -> None:
@@ -763,8 +687,4 @@ class DanfossAlly:
         _LOGGER.debug(
             "  unsupported_status_devices=%s",
             ", ".join(diagnostics["unsupported_status_devices"]) or "none",
-        )
-        _LOGGER.debug(
-            "  skipped_write_calls=%s",
-            diagnostics["skipped_write_calls"],
         )

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -520,7 +520,6 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("requests./ally/devices=1", log_output)
         self.assertIn("unsupported_status_device_count=0", log_output)
         self.assertIn("unsupported_status_devices=none", log_output)
-        self.assertIn("skipped_write_calls=0", log_output)
 
     async def test_refresh_device_uses_status_endpoint_when_supported(self) -> None:
         """High-priority devices should prefer the status endpoint."""
@@ -977,10 +976,12 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(await ally.set_temperature("device-1", 22.0, code="temp_set"))
 
-    async def test_set_temperature_skips_write_when_cached_value_matches(self) -> None:
-        """Identical cached setpoints should not trigger a redundant API write."""
+    async def test_set_temperature_still_writes_when_cached_value_matches(self) -> None:
+        """Explicit temperature writes should still reach the API even if cache matches."""
+        command_calls = 0
 
         def handler(request: MockRequest) -> MockResponse:
+            nonlocal command_calls
             if request.url.path == "/oauth2/token":
                 return MockResponse(200, json_data=TOKEN_RESPONSE)
             if request.url.path == "/ally/devices":
@@ -989,9 +990,13 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
                     json_data={"result": [THERMOSTAT_WITH_MODE_SETPOINTS], "t": 1},
                 )
             if request.url.path == "/ally/devices/device-1/commands":
-                raise AssertionError(
-                    "No command request expected for unchanged setpoint"
+                command_calls += 1
+                payload = json.loads(request.content.decode())
+                self.assertEqual(
+                    payload,
+                    {"commands": [{"code": "manual_mode_fast", "value": 215}]},
                 )
+                return MockResponse(201, json_data={"result": True, "t": 16})
             raise AssertionError(f"Unexpected request: {request.method} {request.url}")
 
         ally = DanfossAlly(api=await self._make_api(handler))
@@ -1001,34 +1006,12 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(
             await ally.set_temperature("device-1", 21.5, code="manual_mode_fast")
         )
+        self.assertEqual(command_calls, 1)
 
-    async def test_set_temperature_for_mode_skips_mode_and_setpoint_when_unchanged(
+    async def test_set_temperature_for_mode_still_writes_when_cache_matches(
         self,
     ) -> None:
-        """Mode-aware writes should short-circuit when cached mode and setpoint match."""
-
-        def handler(request: MockRequest) -> MockResponse:
-            if request.url.path == "/oauth2/token":
-                return MockResponse(200, json_data=TOKEN_RESPONSE)
-            if request.url.path == "/ally/devices":
-                return MockResponse(
-                    200,
-                    json_data={"result": [THERMOSTAT_WITH_MODE_SETPOINTS], "t": 1},
-                )
-            if request.url.path == "/ally/devices/device-1/commands":
-                raise AssertionError(
-                    "No command request expected for unchanged mode write"
-                )
-            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
-
-        ally = DanfossAlly(api=await self._make_api(handler))
-        await ally.initialize("key", "secret")
-        await ally.get_devices()
-
-        self.assertTrue(await ally.set_temperature_for_mode("device-1", 21.5, "manual"))
-
-    async def test_set_temperature_for_mode_only_sends_changed_portion(self) -> None:
-        """Mode-aware writes may skip the separate mode call and still send setpoint changes."""
+        """Mode-aware writes should still send mode and setpoint when explicitly requested."""
         command_payloads: list[dict[str, object]] = []
 
         def handler(request: MockRequest) -> MockResponse:
@@ -1042,11 +1025,44 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             if request.url.path == "/ally/devices/device-1/commands":
                 payload = json.loads(request.content.decode())
                 command_payloads.append(payload)
-                self.assertEqual(
-                    payload,
-                    {"commands": [{"code": "manual_mode_fast", "value": 230}]},
+                return MockResponse(201, json_data={"result": True, "t": 17})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        self.assertTrue(await ally.set_temperature_for_mode("device-1", 21.5, "manual"))
+        self.assertEqual(
+            command_payloads,
+            [
+                {"commands": [{"code": "mode", "value": "manual"}]},
+                {"commands": [{"code": "manual_mode_fast", "value": 215}]},
+            ],
+        )
+
+    async def test_set_temperature_for_mode_sends_full_explicit_flow(self) -> None:
+        """Mode-aware writes should send both calls even if cached mode already matches."""
+        command_payloads: list[dict[str, object]] = []
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(
+                    200,
+                    json_data={"result": [THERMOSTAT_WITH_MODE_SETPOINTS], "t": 1},
                 )
-                return MockResponse(201, json_data={"result": True, "t": 7})
+            if request.url.path == "/ally/devices/device-1/commands":
+                payload = json.loads(request.content.decode())
+                command_payloads.append(payload)
+                if payload == {"commands": [{"code": "mode", "value": "manual"}]}:
+                    return MockResponse(201, json_data={"result": True, "t": 6})
+                if payload == {
+                    "commands": [{"code": "manual_mode_fast", "value": 230}]
+                }:
+                    return MockResponse(201, json_data={"result": True, "t": 7})
+                raise AssertionError(f"Unexpected command payload: {payload}")
             raise AssertionError(f"Unexpected request: {request.method} {request.url}")
 
         ally = DanfossAlly(api=await self._make_api(handler))
@@ -1054,7 +1070,13 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         await ally.get_devices()
 
         self.assertTrue(await ally.set_temperature_for_mode("device-1", 23.0, "manual"))
-        self.assertEqual(len(command_payloads), 1)
+        self.assertEqual(
+            command_payloads,
+            [
+                {"commands": [{"code": "mode", "value": "manual"}]},
+                {"commands": [{"code": "manual_mode_fast", "value": 230}]},
+            ],
+        )
 
     async def test_set_temperature_for_mode_sets_mode_before_mode_setpoint(
         self,
@@ -1140,10 +1162,10 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(await ally.set_external_temperature("device-1", 25.0))
 
-    async def test_set_external_temperature_skips_write_when_cached_state_matches(
+    async def test_set_external_temperature_still_writes_when_cached_state_matches(
         self,
     ) -> None:
-        """External temperature writes should be skipped when cached values already match."""
+        """Explicit external temperature writes should still reach the API if cache matches."""
         cached_device = {
             **DEVICE_PAYLOAD,
             "status": [
@@ -1159,9 +1181,18 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             if request.url.path == "/ally/devices":
                 return MockResponse(200, json_data={"result": [cached_device], "t": 1})
             if request.url.path == "/ally/devices/device-1/commands":
-                raise AssertionError(
-                    "No command request expected for unchanged external temperature"
+                payload = json.loads(request.content.decode())
+                self.assertEqual(
+                    payload,
+                    {
+                        "commands": [
+                            {"code": "radiator_covered", "value": True},
+                            {"code": "ext_measured_rs", "value": 2500},
+                            {"code": "sensor_avg_temp", "value": 250},
+                        ]
+                    },
                 )
+                return MockResponse(201, json_data={"result": True, "t": 18})
             raise AssertionError(f"Unexpected request: {request.method} {request.url}")
 
         ally = DanfossAlly(api=await self._make_api(handler))
@@ -1209,10 +1240,10 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(await ally.set_external_temperature("device-1", 25.0))
 
-    async def test_diagnostics_track_skipped_write_calls_and_unsupported_status(
+    async def test_diagnostics_track_unsupported_status(
         self,
     ) -> None:
-        """Wrapper diagnostics should expose skipped writes and unsupported status devices."""
+        """Wrapper diagnostics should expose unsupported status devices."""
 
         def handler(request: MockRequest) -> MockResponse:
             if request.url.path == "/oauth2/token":
@@ -1228,6 +1259,8 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
                     200,
                     json_data={"result": ROOM_SENSOR_PAYLOAD, "t": 15},
                 )
+            if request.url.path == "/ally/devices/device-1/commands":
+                return MockResponse(201, json_data={"result": True, "t": 16})
             raise AssertionError(f"Unexpected request: {request.method} {request.url}")
 
         ally = DanfossAlly(api=await self._make_api(handler))
@@ -1240,7 +1273,6 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         diagnostics = ally.get_diagnostics()
 
-        self.assertEqual(diagnostics["skipped_write_calls"], 1)
         self.assertEqual(diagnostics["unsupported_status_device_count"], 1)
         self.assertEqual(diagnostics["unsupported_status_devices"], ["sensor-1"])
 


### PR DESCRIPTION
## Summary
Always send explicit device writes to the Danfoss Ally API even when cached state appears unchanged.

## Changes
The client no longer skips explicit write calls based on cached device state. This restores the behavior where calls such as external temperature updates are always sent to the API, which avoids stale-cache assumptions preventing needed writes after device-side resets or time-based expiry.

The write-related diagnostics were simplified accordingly by removing skipped-write tracking, and the tests were updated to assert that explicit writes always reach the API while the rest of the refresh and diagnostics behavior remains unchanged.

## Testing
- `poetry run ruff check pydanfossally tests`
- `poetry run python -m pytest tests/test_async_client.py`

## Notes
- Base branch: `master`
- Release/semver label confirmed with user as `patch`
