### PR TITLE
Implement hot refresh split with diagnostics logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ ally = DanfossAlly(
     refresh_device_min_interval=0.10,
     device_discovery_interval=600,
     degraded_refresh_cooldown=600,
+    hot_refresh_timeout=300,
     user_agent_prefix="HomeAssistant-DanfossAlly/2026.3.0",
 )
 
@@ -71,6 +72,7 @@ async def main() -> None:
         refresh_device_min_interval=0.10,
         device_discovery_interval=600,
         degraded_refresh_cooldown=600,
+        hot_refresh_timeout=300,
         user_agent_prefix="HomeAssistant-DanfossAlly/2026.3.0",
     ) as ally:
         authorized = await ally.initialize(os.environ["KEY"], os.environ["SECRET"])
@@ -116,25 +118,23 @@ device-specific status or command codes. That means:
 
 ## Refresh behavior
 
-The library uses a hybrid refresh strategy. Bulk reads from `GET /ally/devices` populate the
-cache, refresh low-priority devices such as gateways, and run again every 10 minutes to keep
-discovery current. High-priority devices such as thermostats and room sensors prefer the
-lighter `GET /ally/devices/{device_id}/status` endpoint, and the returned statuses are merged
-with cached metadata before parsing.
+Each `refresh_devices()` call always starts with a bulk read from `GET /ally/devices`.
 
-If the API responds with HTTP 429 during per-device refreshes, the client enters a temporary
-bulk-only cooldown. Once the cooldown expires, per-device refreshes resume gradually instead of
-all at once.
+After successful write operations (`set_mode(...)` and `send_command(...)`), the target device is
+tracked as pending hot refresh. While pending, `refresh_devices()` also calls
+`GET /ally/devices/{device_id}/status` for that device.
 
-Both knobs are configurable through `DanfossAlly(...)`:
+Hot refresh for a pending device stops when either of these conditions is met:
 
-- `refresh_device_concurrency` controls how many per-device refreshes may run at once
+- the latest bulk snapshot differs from the baseline state captured when the write succeeded
+- the hot refresh timeout is reached (default: 300 seconds / 5 minutes)
+
+The refresh tuning knobs are configurable through `DanfossAlly(...)`:
+
+- `refresh_device_concurrency` controls how many status hot refresh calls may run at once
 - `refresh_device_min_interval` controls the minimum delay in seconds between starting two
-  per-device refreshes
-- `device_discovery_interval` controls how often the bulk `/ally/devices` endpoint is used to
-  discover newly added devices and refresh low-priority ones
-- `degraded_refresh_cooldown` controls how long the client stays in bulk-only mode after a
-  per-device refresh is rate limited
+  status hot refresh calls
+- `hot_refresh_timeout` controls how long a device stays in pending hot refresh mode
 
 ## User-Agent
 

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -25,7 +25,7 @@ from .danfossallyapi import (
     DIAGNOSTIC_WINDOW_SECONDS,
     DanfossAllyAPI,
 )
-from .exceptions import InternalServerError, RateLimitError
+from .exceptions import InternalServerError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -156,6 +156,7 @@ class DanfossAlly:
         refresh_device_min_interval: float = REFRESH_DEVICE_MIN_INTERVAL,
         device_discovery_interval: float = DEVICE_DISCOVERY_INTERVAL,
         degraded_refresh_cooldown: float = DEGRADED_REFRESH_COOLDOWN,
+        hot_refresh_timeout: float = 300.0,
         user_agent_prefix: str | None = None,
     ) -> None:
         """Initialize the connector."""
@@ -167,6 +168,8 @@ class DanfossAlly:
             raise ValueError("device_discovery_interval must be non-negative")
         if degraded_refresh_cooldown < 0:
             raise ValueError("degraded_refresh_cooldown must be non-negative")
+        if hot_refresh_timeout < 0:
+            raise ValueError("hot_refresh_timeout must be non-negative")
 
         self._authorized = False
         self._token: str | None = None
@@ -180,6 +183,7 @@ class DanfossAlly:
         self._refresh_device_min_interval = refresh_device_min_interval
         self._device_discovery_interval = device_discovery_interval
         self._degraded_refresh_cooldown = degraded_refresh_cooldown
+        self._hot_refresh_timeout = hot_refresh_timeout
         self._diagnostic_window = DIAGNOSTIC_WINDOW_SECONDS
         self._refresh_rate_lock = asyncio.Lock()
         self._next_refresh_slot = 0.0
@@ -187,6 +191,7 @@ class DanfossAlly:
         self._degraded_refresh_until = 0.0
         self._status_refresh_recovery_limit: int | None = None
         self._status_refresh_unsupported: dict[str, float] = {}
+        self._pending_hot_refresh: dict[str, dict[str, Any]] = {}
         self._skipped_refresh_times: dict[str, deque[float]] = defaultdict(deque)
         self._degraded_mode_entry_times: deque[float] = deque()
 
@@ -340,64 +345,36 @@ class DanfossAlly:
             await asyncio.sleep(delay)
 
     async def refresh_devices(self) -> dict[str, dict[str, Any]]:
-        """Refresh cached devices with hybrid bulk and per-device reads."""
+        """Refresh cached devices with bulk snapshots and pending-write hot refreshes."""
         if not self.devices:
             _LOGGER.debug(
                 "Refresh requested without cached devices; loading bulk snapshot for discovery",
             )
             return await self.get_devices()
 
-        if self._should_refresh_device_discovery():
-            _LOGGER.debug(
-                "Device discovery interval elapsed; refreshing bulk device snapshot"
-            )
-            await self.get_devices()
+        await self.get_devices()
+        self._prune_pending_hot_refreshes()
 
-        device_ids = self._get_high_priority_refresh_candidates()
+        device_ids = [
+            device_id
+            for device_id in self._pending_hot_refresh
+            if device_id in self._device_metadata
+            and device_id not in self._status_refresh_unsupported
+        ]
         if not device_ids:
-            self._record_skipped_refresh("no_high_priority_candidates")
-            _LOGGER.debug("No high-priority devices eligible for per-device refresh")
             return self.devices
-
-        if self._is_degraded_refresh_active():
-            self._record_skipped_refresh("degraded_mode", len(device_ids))
-            _LOGGER.debug(
-                "Per-device refreshes are in cooldown until %.3f; returning bulk-backed cache only",
-                self._degraded_refresh_until,
-            )
-            return self.devices
-
-        recovery_limit = self._status_refresh_recovery_limit
-        if recovery_limit is not None:
-            device_ids = device_ids[:recovery_limit]
 
         semaphore = asyncio.Semaphore(self._refresh_device_concurrency)
-        rate_limited = False
 
         async def refresh_one(device_id: str) -> None:
-            nonlocal rate_limited
             async with semaphore:
-                if rate_limited:
-                    self._record_skipped_refresh("rate_limited_remainder")
-                    return
                 await self._wait_for_refresh_slot()
                 try:
-                    await self.refresh_device(device_id)
-                except RateLimitError:
-                    rate_limited = True
-                    self._enter_degraded_refresh_mode()
+                    await self.refresh_device_status(device_id)
+                except InternalServerError:
+                    self._status_refresh_unsupported[device_id] = time.monotonic()
 
         await asyncio.gather(*(refresh_one(device_id) for device_id in device_ids))
-
-        if not rate_limited:
-            self._advance_status_refresh_recovery(
-                len(self._get_high_priority_refresh_candidates())
-            )
-
-        _LOGGER.debug(
-            "Refreshed %s high-priority device(s) via hybrid endpoint selection",
-            len(device_ids),
-        )
         return self.devices
 
     def _should_refresh_device_discovery(self) -> bool:
@@ -493,7 +470,10 @@ class DanfossAlly:
     async def set_mode(self, device_id: str, mode: str) -> bool:
         """Update operating mode for one device."""
         _LOGGER.debug("Setting mode for device %s to %s", device_id, mode)
-        return await self._api.set_mode(device_id, mode)
+        result = await self._api.set_mode(device_id, mode)
+        if result:
+            self._mark_pending_hot_refresh(device_id)
+        return result
 
     async def send_command(
         self,
@@ -506,7 +486,10 @@ class DanfossAlly:
             device_id,
             [code for code, _ in listofcommands],
         )
-        return await self._api.send_command(device_id, listofcommands)
+        result = await self._api.send_command(device_id, listofcommands)
+        if result:
+            self._mark_pending_hot_refresh(device_id)
+        return result
 
     def _store_device(
         self,
@@ -622,6 +605,27 @@ class DanfossAlly:
             total_candidates,
             self._status_refresh_recovery_limit * 2,
         )
+
+    def _mark_pending_hot_refresh(self, device_id: str) -> None:
+        """Track a device for status hot refresh after a successful write."""
+        self._pending_hot_refresh[device_id] = {
+            "baseline": self.devices.get(device_id, {}).copy(),
+            "deadline": time.monotonic() + self._hot_refresh_timeout,
+        }
+
+    def _prune_pending_hot_refreshes(self) -> None:
+        """Stop hot refresh when bulk data changed or timeout has passed."""
+        now = time.monotonic()
+        completed: list[str] = []
+        for device_id, state in self._pending_hot_refresh.items():
+            if now >= state["deadline"]:
+                completed.append(device_id)
+                continue
+            if self.devices.get(device_id) != state.get("baseline", {}):
+                completed.append(device_id)
+
+        for device_id in completed:
+            self._pending_hot_refresh.pop(device_id, None)
 
     def _get_setpoint_code_for_mode(self, device: dict[str, Any], mode: str) -> str:
         """Resolve the Danfoss setpoint field for one mode."""

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -354,6 +354,7 @@ class DanfossAlly:
             return await self.get_devices()
 
         await self.get_devices()
+        self._prune_pending_hot_refreshes()
 
         device_ids = [
             device_id
@@ -664,13 +665,10 @@ class DanfossAlly:
             if timestamps:
                 skipped_refreshes[reason] = len(timestamps)
 
-        self._prune_timestamps(self._degraded_mode_entry_times)
-
         pending_hot_refresh_devices = sorted(self._pending_hot_refresh)
         return {
             "request_counts": self._api.get_diagnostics()["request_counts"],
             "skipped_refreshes": dict(sorted(skipped_refreshes.items())),
-            "degraded_mode_entries": len(self._degraded_mode_entry_times),
             "pending_hot_refresh_devices": pending_hot_refresh_devices,
             "pending_hot_refresh_device_count": len(pending_hot_refresh_devices),
         }
@@ -687,10 +685,6 @@ class DanfossAlly:
             _LOGGER.debug("  requests.%s=%s", endpoint, count)
         for reason, count in diagnostics["skipped_refreshes"].items():
             _LOGGER.debug("  skipped_refreshes.%s=%s", reason, count)
-        _LOGGER.debug(
-            "  degraded_mode_entries=%s",
-            diagnostics["degraded_mode_entries"],
-        )
         _LOGGER.debug(
             "  pending_hot_refresh_device_count=%s",
             diagnostics["pending_hot_refresh_device_count"],

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -621,7 +621,13 @@ class DanfossAlly:
             if now >= state["deadline"]:
                 completed.append(device_id)
                 continue
-            if self.devices.get(device_id) != state.get("baseline", {}):
+
+            baseline = state.get("baseline")
+            if isinstance(baseline, dict):
+                if baseline and self.devices.get(device_id) != baseline:
+                    completed.append(device_id)
+                    continue
+            elif baseline is not None and self.devices.get(device_id) != baseline:
                 completed.append(device_id)
 
         for device_id in completed:

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -263,6 +263,7 @@ class DanfossAlly:
             self._store_device(device, last_response_time=bulk_response_time)
 
         self._schedule_next_device_discovery()
+        self._prune_pending_hot_refreshes()
 
         _LOGGER.debug(
             "Loaded %s devices from bulk snapshot with t=%s",
@@ -353,7 +354,6 @@ class DanfossAlly:
             return await self.get_devices()
 
         await self.get_devices()
-        self._prune_pending_hot_refreshes()
 
         device_ids = [
             device_id
@@ -364,11 +364,17 @@ class DanfossAlly:
         if not device_ids:
             return self.devices
 
+        _LOGGER.debug(
+            "Hot refresh polling %s pending device(s): %s",
+            len(device_ids),
+            ", ".join(device_ids),
+        )
         semaphore = asyncio.Semaphore(self._refresh_device_concurrency)
 
         async def refresh_one(device_id: str) -> None:
             async with semaphore:
                 await self._wait_for_refresh_slot()
+                _LOGGER.debug("Polling device %s via hot refresh", device_id)
                 try:
                     await self.refresh_device_status(device_id)
                 except InternalServerError:
@@ -660,18 +666,13 @@ class DanfossAlly:
 
         self._prune_timestamps(self._degraded_mode_entry_times)
 
-        cutoff = time.monotonic() - self._diagnostic_window
-        unsupported_status_devices = sorted(
-            device_id
-            for device_id, seen_at in self._status_refresh_unsupported.items()
-            if seen_at >= cutoff
-        )
+        pending_hot_refresh_devices = sorted(self._pending_hot_refresh)
         return {
             "request_counts": self._api.get_diagnostics()["request_counts"],
             "skipped_refreshes": dict(sorted(skipped_refreshes.items())),
             "degraded_mode_entries": len(self._degraded_mode_entry_times),
-            "unsupported_status_devices": unsupported_status_devices,
-            "unsupported_status_device_count": len(unsupported_status_devices),
+            "pending_hot_refresh_devices": pending_hot_refresh_devices,
+            "pending_hot_refresh_device_count": len(pending_hot_refresh_devices),
         }
 
     def _log_diagnostics(self, context: str) -> None:
@@ -691,10 +692,10 @@ class DanfossAlly:
             diagnostics["degraded_mode_entries"],
         )
         _LOGGER.debug(
-            "  unsupported_status_device_count=%s",
-            diagnostics["unsupported_status_device_count"],
+            "  pending_hot_refresh_device_count=%s",
+            diagnostics["pending_hot_refresh_device_count"],
         )
         _LOGGER.debug(
-            "  unsupported_status_devices=%s",
-            ", ".join(diagnostics["unsupported_status_devices"]) or "none",
+            "  pending_hot_refresh_devices=%s",
+            ", ".join(diagnostics["pending_hot_refresh_devices"]) or "none",
         )

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -6,7 +6,7 @@ import asyncio
 import copy
 import json
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from yarl import URL
 
@@ -651,7 +651,7 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_refresh_devices_limits_parallelism_to_five(self) -> None:
-        """Cached device refreshes should use bounded parallelism."""
+        """Pending hot refreshes should use bounded parallelism."""
         ally = DanfossAlly(
             api=await self._make_api(lambda request: MockResponse(200)),
             refresh_device_concurrency=5,
@@ -665,11 +665,15 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
                     name=f" Thermostat {idx} ",
                 )
             )
+            ally._pending_hot_refresh[f"device-{idx}"] = {  # type: ignore[attr-defined]
+                "baseline": {},
+                "deadline": float("inf"),
+            }
 
         active_calls = 0
         max_active_calls = 0
 
-        async def fake_refresh_device(device_id: str) -> dict[str, object]:
+        async def fake_refresh_device_status(device_id: str) -> dict[str, object]:
             nonlocal active_calls, max_active_calls
             active_calls += 1
             max_active_calls = max(max_active_calls, active_calls)
@@ -677,14 +681,15 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             active_calls -= 1
             return {"id": device_id}
 
-        ally.refresh_device = fake_refresh_device  # type: ignore[method-assign]
+        ally.refresh_device_status = fake_refresh_device_status  # type: ignore[method-assign]
+        ally.get_devices = AsyncMock(return_value=ally.devices)  # type: ignore[method-assign]
 
         await ally.refresh_devices()
 
         self.assertEqual(max_active_calls, 5)
 
     async def test_refresh_devices_rate_limits_device_reads(self) -> None:
-        """Cached device refreshes should be paced to avoid request bursts."""
+        """Pending hot refreshes should be paced to avoid request bursts."""
         ally = DanfossAlly(
             api=await self._make_api(lambda request: MockResponse(200)),
             refresh_device_min_interval=0.02,
@@ -697,14 +702,19 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
                     name=f" Thermostat {idx} ",
                 )
             )
+            ally._pending_hot_refresh[f"device-{idx}"] = {  # type: ignore[attr-defined]
+                "baseline": {},
+                "deadline": float("inf"),
+            }
 
         started_at: list[float] = []
 
-        async def fake_refresh_device(device_id: str) -> dict[str, object]:
+        async def fake_refresh_device_status(device_id: str) -> dict[str, object]:
             started_at.append(asyncio.get_running_loop().time())
             return {"id": device_id}
 
-        ally.refresh_device = fake_refresh_device  # type: ignore[method-assign]
+        ally.refresh_device_status = fake_refresh_device_status  # type: ignore[method-assign]
+        ally.get_devices = AsyncMock(return_value=ally.devices)  # type: ignore[method-assign]
 
         await ally.refresh_devices()
 
@@ -729,8 +739,62 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("device-1", devices)
 
-    async def test_refresh_devices_skips_bulk_discovery_before_interval(self) -> None:
-        """Known devices should use direct refresh until the discovery interval elapses."""
+    async def test_refresh_devices_always_runs_bulk_snapshot(self) -> None:
+        """Each refresh should always execute one bulk /devices request."""
+        bulk_calls = 0
+
+        def handler(request: MockRequest) -> MockResponse:
+            nonlocal bulk_calls
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                bulk_calls += 1
+                return MockResponse(
+                    200, json_data={"result": [DEVICE_PAYLOAD], "t": bulk_calls}
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(
+            api=await self._make_api(handler), refresh_device_min_interval=0
+        )
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+
+        await ally.refresh_devices()
+
+        self.assertEqual(bulk_calls, 2)
+
+    async def test_refresh_devices_runs_hot_refresh_for_pending_writes(self) -> None:
+        """Refresh should run /status for devices with pending writes."""
+        status_calls: list[str] = []
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices":
+                return MockResponse(200, json_data={"result": [DEVICE_PAYLOAD], "t": 1})
+            if request.url.path == "/ally/devices/device-1/commands":
+                return MockResponse(201, json_data={"result": True, "t": 2})
+            if request.url.path == "/ally/devices/device-1/status":
+                status_calls.append("device-1")
+                return MockResponse(
+                    200, json_data={"result": DEVICE_PAYLOAD["status"], "t": 3}
+                )
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(
+            api=await self._make_api(handler), refresh_device_min_interval=0
+        )
+        await ally.initialize("key", "secret")
+        await ally.get_devices()
+        await ally.send_command("device-1", [("temp_set", 220)])
+
+        await ally.refresh_devices()
+
+        self.assertEqual(status_calls, ["device-1"])
+
+    async def test_refresh_devices_stops_hot_refresh_when_bulk_changes(self) -> None:
+        """Pending hot refresh should stop once bulk data shows a changed device state."""
         bulk_calls = 0
         status_calls = 0
 
@@ -740,117 +804,31 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
                 return MockResponse(200, json_data=TOKEN_RESPONSE)
             if request.url.path == "/ally/devices":
                 bulk_calls += 1
-                return MockResponse(200, json_data={"result": [DEVICE_PAYLOAD], "t": 1})
+                payload = clone_device_payload(DEVICE_PAYLOAD)
+                if bulk_calls >= 2:
+                    payload["status"][0]["value"] = 230
+                return MockResponse(
+                    200, json_data={"result": [payload], "t": bulk_calls}
+                )
+            if request.url.path == "/ally/devices/device-1/commands":
+                return MockResponse(201, json_data={"result": True, "t": 2})
             if request.url.path == "/ally/devices/device-1/status":
                 status_calls += 1
                 return MockResponse(
-                    200,
-                    json_data={
-                        "result": [
-                            {"code": "temp_set", "value": 230},
-                            {"code": "temp_current", "value": 205},
-                        ],
-                        "t": 2,
-                    },
+                    200, json_data={"result": DEVICE_PAYLOAD["status"], "t": 3}
                 )
             raise AssertionError(f"Unexpected request: {request.method} {request.url}")
 
         ally = DanfossAlly(
-            api=await self._make_api(handler),
-            refresh_device_min_interval=0,
-            device_discovery_interval=3600,
+            api=await self._make_api(handler), refresh_device_min_interval=0
         )
         await ally.initialize("key", "secret")
         await ally.get_devices()
+        await ally.send_command("device-1", [("temp_set", 220)])
 
         await ally.refresh_devices()
 
-        self.assertEqual(bulk_calls, 1)
-        self.assertEqual(status_calls, 1)
-
-    async def test_refresh_devices_renews_bulk_discovery_after_interval(self) -> None:
-        """Hourly discovery should pick up new devices before direct refresh."""
-        bulk_calls = 0
-        status_calls: list[str] = []
-        second_device = clone_device_payload(
-            DEVICE_PAYLOAD,
-            device_id="device-2",
-            name=" Bedroom ",
-        )
-
-        def handler(request: MockRequest) -> MockResponse:
-            nonlocal bulk_calls
-            if request.url.path == "/oauth2/token":
-                return MockResponse(200, json_data=TOKEN_RESPONSE)
-            if request.url.path == "/ally/devices":
-                bulk_calls += 1
-                if bulk_calls == 1:
-                    return MockResponse(
-                        200, json_data={"result": [DEVICE_PAYLOAD], "t": 1}
-                    )
-                return MockResponse(
-                    200,
-                    json_data={"result": [DEVICE_PAYLOAD, second_device], "t": 2},
-                )
-            if request.url.path.endswith("/status"):
-                device_id = request.url.path.split("/")[-2]
-                status_calls.append(device_id)
-                payload = DEVICE_PAYLOAD if device_id == "device-1" else second_device
-                return MockResponse(
-                    200, json_data={"result": payload["status"], "t": 3}
-                )
-            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
-
-        ally = DanfossAlly(
-            api=await self._make_api(handler),
-            refresh_device_min_interval=0,
-            device_discovery_interval=3600,
-        )
-        await ally.initialize("key", "secret")
-        await ally.get_devices()
-        ally._next_device_discovery_at = asyncio.get_running_loop().time() - 1
-
-        devices = await ally.refresh_devices()
-
-        self.assertEqual(bulk_calls, 2)
-        self.assertCountEqual(status_calls, ["device-1", "device-2"])
-        self.assertIn("device-2", devices)
-
-    async def test_refresh_devices_leaves_low_priority_devices_on_bulk_only(
-        self,
-    ) -> None:
-        """Gateways and similar devices should not use per-device refreshes."""
-        status_calls: list[str] = []
-
-        def handler(request: MockRequest) -> MockResponse:
-            if request.url.path == "/oauth2/token":
-                return MockResponse(200, json_data=TOKEN_RESPONSE)
-            if request.url.path == "/ally/devices":
-                return MockResponse(
-                    200,
-                    json_data={"result": [DEVICE_PAYLOAD, GATEWAY_PAYLOAD], "t": 1},
-                )
-            if request.url.path == "/ally/devices/device-1/status":
-                status_calls.append("device-1")
-                return MockResponse(
-                    200,
-                    json_data={"result": DEVICE_PAYLOAD["status"], "t": 2},
-                )
-            if request.url.path.startswith("/ally/devices/gateway-1"):
-                raise AssertionError("Gateway should remain bulk-only")
-            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
-
-        ally = DanfossAlly(
-            api=await self._make_api(handler),
-            refresh_device_min_interval=0,
-            device_discovery_interval=3600,
-        )
-        await ally.initialize("key", "secret")
-        await ally.get_devices()
-
-        await ally.refresh_devices()
-
-        self.assertEqual(status_calls, ["device-1"])
+        self.assertEqual(status_calls, 0)
 
     def test_known_low_priority_device_types_are_bulk_only(self) -> None:
         """Known infrastructure device types should stay out of high-priority refreshes."""
@@ -877,49 +855,29 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             DanfossAlly(degraded_refresh_cooldown=-0.1)
 
-    async def test_refresh_devices_enters_degraded_mode_on_rate_limit(self) -> None:
-        """429 during per-device refresh should trigger bulk-only cooldown and recovery."""
+        with self.assertRaises(ValueError):
+            DanfossAlly(hot_refresh_timeout=-0.1)
+
+    async def test_refresh_devices_stops_hot_refresh_on_timeout(self) -> None:
+        """Pending hot refresh should stop after the configured timeout."""
         ally = DanfossAlly(
             api=await self._make_api(lambda request: MockResponse(200)),
-            refresh_device_concurrency=1,
             refresh_device_min_interval=0,
-            degraded_refresh_cooldown=30,
+            hot_refresh_timeout=0,
         )
         ally._store_device(clone_device_payload(DEVICE_PAYLOAD, device_id="device-1"))  # type: ignore[attr-defined]
-        ally._store_device(clone_device_payload(DEVICE_PAYLOAD, device_id="device-2"))  # type: ignore[attr-defined]
+        ally._pending_hot_refresh["device-1"] = {  # type: ignore[attr-defined]
+            "baseline": ally.devices["device-1"].copy(),
+            "deadline": 0.0,
+        }
 
-        refreshed_ids: list[str] = []
-        attempts = 0
-
-        async def fake_refresh_device(device_id: str) -> dict[str, object]:
-            nonlocal attempts
-            attempts += 1
-            if attempts == 1:
-                raise RateLimitError()
-            refreshed_ids.append(device_id)
-            return {"id": device_id}
-
-        ally.refresh_device = fake_refresh_device  # type: ignore[method-assign]
+        ally.get_devices = AsyncMock(return_value=ally.devices)  # type: ignore[method-assign]
+        ally.refresh_device_status = AsyncMock()  # type: ignore[method-assign]
 
         await ally.refresh_devices()
-        self.assertGreater(
-            ally._degraded_refresh_until,  # type: ignore[attr-defined]
-            asyncio.get_running_loop().time(),
-        )
 
-        await ally.refresh_devices()
-        self.assertEqual(refreshed_ids, [])
-
-        ally._degraded_refresh_until = asyncio.get_running_loop().time() - 1  # type: ignore[attr-defined]
-        await ally.refresh_devices()
-        self.assertEqual(refreshed_ids, ["device-1"])
-
-        await ally.refresh_devices()
-        self.assertCountEqual(refreshed_ids, ["device-1", "device-1", "device-2"])
-
-        diagnostics = ally.get_diagnostics()
-        self.assertEqual(diagnostics["degraded_mode_entries"], 1)
-        self.assertEqual(diagnostics["skipped_refreshes"]["degraded_mode"], 2)
+        ally.refresh_device_status.assert_not_called()  # type: ignore[attr-defined]
+        self.assertEqual(ally._pending_hot_refresh, {})  # type: ignore[attr-defined]
 
     async def test_global_rate_limit_paces_reads_and_writes(self) -> None:
         """All outbound API calls should share the same global pacing."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -518,8 +518,8 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             log_output,
         )
         self.assertIn("requests./ally/devices=1", log_output)
-        self.assertIn("unsupported_status_device_count=0", log_output)
-        self.assertIn("unsupported_status_devices=none", log_output)
+        self.assertIn("pending_hot_refresh_device_count=0", log_output)
+        self.assertIn("pending_hot_refresh_devices=none", log_output)
 
     async def test_refresh_device_uses_status_endpoint_when_supported(self) -> None:
         """High-priority devices should prefer the status endpoint."""
@@ -789,9 +789,13 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         await ally.get_devices()
         await ally.send_command("device-1", [("temp_set", 220)])
 
-        await ally.refresh_devices()
+        with self.assertLogs("pydanfossally", level="DEBUG") as captured_logs:
+            await ally.refresh_devices()
 
         self.assertEqual(status_calls, ["device-1"])
+        log_output = "\n".join(captured_logs.output)
+        self.assertIn("Hot refresh polling 1 pending device(s): device-1", log_output)
+        self.assertIn("Polling device device-1 via hot refresh", log_output)
 
     async def test_refresh_devices_stops_hot_refresh_when_bulk_changes(self) -> None:
         """Pending hot refresh should stop once bulk data shows a changed device state."""
@@ -1231,8 +1235,8 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         diagnostics = ally.get_diagnostics()
 
-        self.assertEqual(diagnostics["unsupported_status_device_count"], 1)
-        self.assertEqual(diagnostics["unsupported_status_devices"], ["sensor-1"])
+        self.assertEqual(diagnostics["pending_hot_refresh_device_count"], 1)
+        self.assertEqual(diagnostics["pending_hot_refresh_devices"], ["device-1"])
 
     async def test_set_radiator_covered_false_clears_external_temperature(self) -> None:
         """Disabling covered-radiator mode should clear external sensor values."""


### PR DESCRIPTION
## Summary
This PR updates the refresh flow so each refresh starts with a bulk device snapshot and only performs status hot refresh for devices with pending writes. It also adds clearer diagnostics and debug logging around hot refresh activity.

## Changes
The refresh flow now always starts with `/ally/devices`, while pending writes are tracked separately and refreshed through `/ally/devices/{device_id}/status`. Hot refresh stops automatically when the bulk snapshot shows changed state or when the configured timeout expires.

Diagnostics now report how many devices are currently pending hot refresh and list which device ids are involved. Debug logging also shows which devices are being polled as hot refresh candidates. The debug overview was trimmed to remove old unsupported-status and degraded-mode counters that are no longer relevant to this flow.

## Testing
- `ruff format .`
- `ruff check .`
- `.venv/bin/python -m pytest -q`

## Notes
Proposed semver label: `minor`.
The semver label has not been applied yet and should be explicitly verified before it is set or changed.
