### PR TITLE
Add writable temperature setting helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ By default, the client sends a `User-Agent` header in the form `pydanfossally/<v
 Integrations can prepend their own identifier through `user_agent_prefix`, resulting in a final
 header such as `HomeAssistant-DanfossAlly/2026.3.0 pydanfossally/<version>`.
 
+## Writable temperature helpers
+
+The client includes explicit helpers for several writable temperature-like settings:
+
+- `set_upper_temp(device_id, temp)`
+- `set_lower_temp(device_id, temp)`
+- `set_at_home_setting(device_id, temp)`
+- `set_leaving_home_setting(device_id, temp)`
+- `set_holiday_setting(device_id, temp)`
+
+These helpers validate values before writing them:
+
+- minimum `5.0`
+- maximum `35.0`
+- only `0.5` degree steps
+
 ## Local verification
 
 The repository includes `example.py` as a small async read-only example that uses credentials

--- a/README.md
+++ b/README.md
@@ -158,6 +158,33 @@ These helpers validate values before writing them:
 - maximum `35.0`
 - only `0.5` degree steps
 
+Example:
+
+```python
+devices = await ally.get_devices()
+device = devices["device-1"]
+
+await ally.set_upper_temp("device-1", 28.0)
+await ally.set_lower_temp("device-1", 7.0)
+await ally.set_at_home_setting("device-1", 21.5)
+await ally.set_leaving_home_setting("device-1", 17.0)
+await ally.set_holiday_setting("device-1", 15.0)
+
+await ally.refresh_device("device-1")
+device = ally.devices["device-1"]
+
+print(device["upper_temp"])
+print(device["lower_temp"])
+print(device["at_home_setting"])
+print(device["leaving_home_setting"])
+print(device["holiday_setting"])
+```
+
+Read access for these values is exposed through the parsed device state returned by
+`get_devices()`, `get_device()`, `refresh_device()`, and `refresh_devices()`. The library does
+not currently include dedicated getter methods for these fields because they are already part of
+the normal device model.
+
 ## Local verification
 
 The repository includes `example.py` as a small async read-only example that uses credentials

--- a/docs/writable-properties-research.md
+++ b/docs/writable-properties-research.md
@@ -218,6 +218,11 @@ Observed raw status codes on the representative thermostat:
 
 - `manual_mode_fast`, `at_home_setting`, `leaving_home_setting`, `pause_setting`, `holiday_setting`,
   `temp_set`, and `mode` are backed by live evidence on the tested device types.
+- `upper_temp` and `lower_temp` are also backed by live evidence on both tested thermostat models.
+- the library now exposes explicit write helpers for `upper_temp`, `lower_temp`,
+  `at_home_setting`, `leaving_home_setting`, and `holiday_setting`.
+- these values already map into the parsed device state, so read access can continue to use the
+  normal device object rather than dedicated getter methods.
 - `ext_measured_rs` is backed by live evidence on the Ally radiator thermostat and is a valid basis
   for `set_external_temperature()`.
 - `upper_temp` and `lower_temp` are writable on both tested thermostat models, but there is not yet

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict, deque
 import logging
+import math
 import re
 import time
 from typing import Any
@@ -143,6 +144,18 @@ def _normalize_device_type(value: Any) -> str:
         return ""
     normalized = re.sub(r"[^a-z0-9]+", " ", value.lower())
     return " ".join(normalized.split())
+
+
+def _encode_half_degree_temperature_setting(temp: float) -> int:
+    """Encode a bounded temperature setting to Danfoss tenth-degree scale."""
+    if not 5.0 <= temp <= 35.0:
+        raise ValueError("temperature setting must be between 5.0 and 35.0")
+
+    half_steps = temp * 2
+    if not math.isclose(half_steps, round(half_steps), abs_tol=1e-9):
+        raise ValueError("temperature setting must use 0.5 degree steps")
+
+    return int(round(temp * 10))
 
 
 class DanfossAlly:
@@ -460,6 +473,42 @@ class DanfossAlly:
     async def set_manual_temperature(self, device_id: str, temp: float) -> bool:
         """Apply a manual temperature override for one device."""
         return await self.set_temperature_for_mode(device_id, temp, "manual")
+
+    async def _set_temperature_setting(
+        self,
+        device_id: str,
+        temp: float,
+        code: str,
+    ) -> bool:
+        """Write one bounded half-degree temperature-like setting."""
+        return await self.send_command(
+            device_id,
+            [(code, _encode_half_degree_temperature_setting(temp))],
+        )
+
+    async def set_upper_temp(self, device_id: str, temp: float) -> bool:
+        """Set the upper temperature limit for one device."""
+        return await self._set_temperature_setting(device_id, temp, "upper_temp")
+
+    async def set_lower_temp(self, device_id: str, temp: float) -> bool:
+        """Set the lower temperature limit for one device."""
+        return await self._set_temperature_setting(device_id, temp, "lower_temp")
+
+    async def set_at_home_setting(self, device_id: str, temp: float) -> bool:
+        """Set the at-home schedule temperature for one device."""
+        return await self._set_temperature_setting(device_id, temp, "at_home_setting")
+
+    async def set_leaving_home_setting(self, device_id: str, temp: float) -> bool:
+        """Set the leaving-home schedule temperature for one device."""
+        return await self._set_temperature_setting(
+            device_id,
+            temp,
+            "leaving_home_setting",
+        )
+
+    async def set_holiday_setting(self, device_id: str, temp: float) -> bool:
+        """Set the holiday schedule temperature for one device."""
+        return await self._set_temperature_setting(device_id, temp, "holiday_setting")
 
     async def set_external_temperature(
         self,

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1136,6 +1136,60 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(await ally.set_manual_temperature("device-1", 22.5))
 
+    async def test_temperature_setting_helpers_send_expected_payloads(self) -> None:
+        """Bounded temperature helpers should write the matching command code."""
+        expected_payloads = [
+            {"commands": [{"code": "upper_temp", "value": 350}]},
+            {"commands": [{"code": "lower_temp", "value": 50}]},
+            {"commands": [{"code": "at_home_setting", "value": 215}]},
+            {"commands": [{"code": "leaving_home_setting", "value": 170}]},
+            {"commands": [{"code": "holiday_setting", "value": 150}]},
+        ]
+        command_payloads: list[dict[str, object]] = []
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            if request.url.path == "/ally/devices/device-1/commands":
+                payload = json.loads(request.content.decode())
+                command_payloads.append(payload)
+                return MockResponse(201, json_data={"result": True, "t": 19})
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        self.assertTrue(await ally.set_upper_temp("device-1", 35.0))
+        self.assertTrue(await ally.set_lower_temp("device-1", 5.0))
+        self.assertTrue(await ally.set_at_home_setting("device-1", 21.5))
+        self.assertTrue(await ally.set_leaving_home_setting("device-1", 17.0))
+        self.assertTrue(await ally.set_holiday_setting("device-1", 15.0))
+        self.assertEqual(command_payloads, expected_payloads)
+
+    async def test_temperature_setting_helpers_validate_range_and_step(self) -> None:
+        """Bounded temperature helpers should reject invalid range and step values."""
+
+        def handler(request: MockRequest) -> MockResponse:
+            if request.url.path == "/oauth2/token":
+                return MockResponse(200, json_data=TOKEN_RESPONSE)
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+        ally = DanfossAlly(api=await self._make_api(handler))
+        await ally.initialize("key", "secret")
+
+        invalid_calls = [
+            (ally.set_upper_temp, 4.5, "between 5.0 and 35.0"),
+            (ally.set_lower_temp, 35.5, "between 5.0 and 35.0"),
+            (ally.set_at_home_setting, 21.3, "0.5 degree steps"),
+            (ally.set_leaving_home_setting, 17.1, "0.5 degree steps"),
+            (ally.set_holiday_setting, 15.25, "0.5 degree steps"),
+        ]
+
+        for method, value, message in invalid_calls:
+            with self.subTest(method=method.__name__, value=value):
+                with self.assertRaisesRegex(ValueError, message):
+                    await method("device-1", value)
+
     async def test_set_external_temperature_enables_radiator_covered(self) -> None:
         """External temperature writes should force covered-radiator mode."""
 


### PR DESCRIPTION
## Summary
Add explicit helpers for writing additional temperature-related properties and document how to use them.

## Changes
The client now exposes dedicated write helpers for `upper_temp`, `lower_temp`, `at_home_setting`, `leaving_home_setting`, and `holiday_setting`. These helpers share one internal validation path so they all enforce the same supported range and increment rules before commands are sent to the API.

The documentation now includes the new helper methods, their validation constraints, and an example showing how to read the updated values back from the parsed device state after a refresh. The writable-properties research note was also updated to reflect the library support that now exists for these commands.

## Testing
- `poetry run ruff format pydanfossally/__init__.py tests/test_async_client.py`
- `poetry run ruff check .`
- `poetry run python -m pytest`

## Notes
- Proposed semver label: `minor`
- Semver label has not been set yet and should be explicitly verified before labeling or merge