### PR TITLE
Add explicit pause setting helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The client includes explicit helpers for several writable temperature-like setti
 - `set_at_home_setting(device_id, temp)`
 - `set_leaving_home_setting(device_id, temp)`
 - `set_holiday_setting(device_id, temp)`
+- `set_pause_setting(device_id, temp)`
 
 These helpers validate values before writing them:
 
@@ -165,6 +166,7 @@ await ally.set_lower_temp("device-1", 7.0)
 await ally.set_at_home_setting("device-1", 21.5)
 await ally.set_leaving_home_setting("device-1", 17.0)
 await ally.set_holiday_setting("device-1", 15.0)
+await ally.set_pause_setting("device-1", 8.0)
 
 await ally.refresh_device("device-1")
 device = ally.devices["device-1"]
@@ -174,6 +176,7 @@ print(device["lower_temp"])
 print(device["at_home_setting"])
 print(device["leaving_home_setting"])
 print(device["holiday_setting"])
+print(device["pause_setting"])
 ```
 
 Read access for these values is exposed through the parsed device state returned by

--- a/pydanfossally/__init__.py
+++ b/pydanfossally/__init__.py
@@ -469,6 +469,10 @@ class DanfossAlly:
         """Set the holiday schedule temperature for one device."""
         return await self._set_temperature_setting(device_id, temp, "holiday_setting")
 
+    async def set_pause_setting(self, device_id: str, temp: float) -> bool:
+        """Set the pause schedule temperature for one device."""
+        return await self._set_temperature_setting(device_id, temp, "pause_setting")
+
     async def set_external_temperature(
         self,
         device_id: str,

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1100,6 +1100,7 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             {"commands": [{"code": "at_home_setting", "value": 215}]},
             {"commands": [{"code": "leaving_home_setting", "value": 170}]},
             {"commands": [{"code": "holiday_setting", "value": 150}]},
+            {"commands": [{"code": "pause_setting", "value": 80}]},
         ]
         command_payloads: list[dict[str, object]] = []
 
@@ -1120,6 +1121,7 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(await ally.set_at_home_setting("device-1", 21.5))
         self.assertTrue(await ally.set_leaving_home_setting("device-1", 17.0))
         self.assertTrue(await ally.set_holiday_setting("device-1", 15.0))
+        self.assertTrue(await ally.set_pause_setting("device-1", 8.0))
         self.assertEqual(command_payloads, expected_payloads)
 
     async def test_temperature_setting_helpers_validate_range_and_step(self) -> None:
@@ -1139,6 +1141,7 @@ class DanfossAllyAsyncTests(unittest.IsolatedAsyncioTestCase):
             (ally.set_at_home_setting, 21.3, "0.5 degree steps"),
             (ally.set_leaving_home_setting, 17.1, "0.5 degree steps"),
             (ally.set_holiday_setting, 15.25, "0.5 degree steps"),
+            (ally.set_pause_setting, 4.0, "between 5.0 and 35.0"),
         ]
 
         for method, value, message in invalid_calls:


### PR DESCRIPTION
## Summary
Add the missing explicit helper for writing `pause_setting` and document it alongside the other writable temperature helpers.

## Changes
The client now exposes `set_pause_setting(device_id, temp)` as a dedicated public helper. It reuses the same internal validation and encoding path as the other temperature-like setting helpers, so it enforces the same supported range and `0.5` degree step size before writing to the API.

The README and async client tests were updated so `pause_setting` is listed consistently with the other writable helpers and covered by the shared validation and payload expectations.

## Testing
- `poetry run ruff format pydanfossally/__init__.py tests/test_async_client.py`
- `poetry run ruff check .`
- `poetry run python -m pytest`

## Notes
- Proposed semver label: `minor`
- Semver label has not been set yet and should be explicitly verified before labeling or merge